### PR TITLE
Add User-Agent fallback for Clash subscription imports

### DIFF
--- a/backend/app_proxy_import.go
+++ b/backend/app_proxy_import.go
@@ -17,6 +17,13 @@ const (
 	clashSubscriptionTimeout  = 25 * time.Second
 )
 
+var clashSubscriptionUserAgents = []string{
+	"clash-verge/2.0 ant-chrome/1.0",
+	"FlClash/v0.8.92 clash-verge Platform/windows",
+	"clash-verge/v2.4.2",
+	"ClashforWindows/0.19.23",
+}
+
 // BrowserProxyFetchClashByURL 拉取 Clash 订阅 URL，并返回可直接导入的 YAML 文本与建议配置。
 func (a *App) BrowserProxyFetchClashByURL(rawURL string) (map[string]interface{}, error) {
 	rawURL = strings.TrimSpace(rawURL)
@@ -33,36 +40,10 @@ func (a *App) BrowserProxyFetchClashByURL(rawURL string) (map[string]interface{}
 		return nil, fmt.Errorf("仅支持 http/https URL")
 	}
 
-	req, err := http.NewRequest(http.MethodGet, parsedURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("创建请求失败: %w", err)
-	}
-	req.Header.Set("User-Agent", "clash-verge/2.0 ant-chrome/1.0")
-	req.Header.Set("Accept", "application/yaml,text/yaml,text/plain,*/*")
-	req.Header.Set("Cache-Control", "no-cache")
-
 	client := &http.Client{
 		Timeout: clashSubscriptionTimeout,
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("拉取订阅失败: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("拉取订阅失败: HTTP %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxClashSubscriptionBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("读取订阅内容失败: %w", err)
-	}
-	if len(body) > maxClashSubscriptionBytes {
-		return nil, fmt.Errorf("订阅内容过大（超过 8MB）")
-	}
-
-	content, payload, err := normalizeClashSubscriptionContent(body)
+	content, payload, err := fetchClashSubscriptionWithFallback(client, parsedURL.String())
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +63,55 @@ func (a *App) BrowserProxyFetchClashByURL(rawURL string) (map[string]interface{}
 		"dnsServers":     dnsYAML,
 		"suggestedGroup": suggestedGroup,
 	}, nil
+}
+
+func fetchClashSubscriptionWithFallback(client *http.Client, targetURL string) (string, interface{}, error) {
+	var lastErr error
+	for _, userAgent := range clashSubscriptionUserAgents {
+		content, payload, err := fetchClashSubscriptionWithUserAgent(client, targetURL, userAgent)
+		if err == nil {
+			return content, payload, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("未配置可用的 User-Agent")
+	}
+	return "", nil, fmt.Errorf("拉取订阅失败: %w", lastErr)
+}
+
+func fetchClashSubscriptionWithUserAgent(client *http.Client, targetURL string, userAgent string) (string, interface{}, error) {
+	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("创建请求失败")
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/yaml,text/yaml,text/plain,*/*")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", nil, fmt.Errorf("网络请求失败")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxClashSubscriptionBytes+1))
+	if err != nil {
+		return "", nil, fmt.Errorf("读取订阅内容失败")
+	}
+	if len(body) > maxClashSubscriptionBytes {
+		return "", nil, fmt.Errorf("订阅内容过大（超过 8MB）")
+	}
+
+	content, payload, err := normalizeClashSubscriptionContent(body)
+	if err != nil {
+		return "", nil, err
+	}
+	return content, payload, nil
 }
 
 func normalizeClashSubscriptionContent(body []byte) (string, interface{}, error) {

--- a/backend/app_proxy_import_test.go
+++ b/backend/app_proxy_import_test.go
@@ -1,0 +1,101 @@
+package backend
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testClashSubscriptionYAML = `
+proxies:
+  - name: test-node
+    type: http
+    server: example.com
+    port: 8080
+`
+
+func TestBrowserProxyFetchClashByURLFallbackAfterHTTPStatus(t *testing.T) {
+	var seenUserAgents []string
+	var seenAccept string
+	var seenCacheControl string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenUserAgents = append(seenUserAgents, r.Header.Get("User-Agent"))
+		if len(seenUserAgents) == 1 {
+			seenAccept = r.Header.Get("Accept")
+			seenCacheControl = r.Header.Get("Cache-Control")
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		fmt.Fprint(w, testClashSubscriptionYAML)
+	}))
+	defer server.Close()
+
+	result, err := (&App{}).BrowserProxyFetchClashByURL(server.URL + "/sub?token=test-token")
+	if err != nil {
+		t.Fatalf("BrowserProxyFetchClashByURL returned error: %v", err)
+	}
+	if got := result["proxyCount"]; got != 1 {
+		t.Fatalf("proxyCount = %v, want 1", got)
+	}
+	if len(seenUserAgents) != 2 {
+		t.Fatalf("request count = %d, want 2", len(seenUserAgents))
+	}
+	if seenUserAgents[0] != clashSubscriptionUserAgents[0] {
+		t.Fatalf("first User-Agent = %q, want %q", seenUserAgents[0], clashSubscriptionUserAgents[0])
+	}
+	if seenUserAgents[1] != clashSubscriptionUserAgents[1] {
+		t.Fatalf("second User-Agent = %q, want %q", seenUserAgents[1], clashSubscriptionUserAgents[1])
+	}
+	if seenAccept != "application/yaml,text/yaml,text/plain,*/*" {
+		t.Fatalf("Accept = %q", seenAccept)
+	}
+	if seenCacheControl != "no-cache" {
+		t.Fatalf("Cache-Control = %q", seenCacheControl)
+	}
+}
+
+func TestBrowserProxyFetchClashByURLFallbackAfterHTMLContent(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, "<html><body>client not supported</body></html>")
+			return
+		}
+		fmt.Fprint(w, testClashSubscriptionYAML)
+	}))
+	defer server.Close()
+
+	result, err := (&App{}).BrowserProxyFetchClashByURL(server.URL)
+	if err != nil {
+		t.Fatalf("BrowserProxyFetchClashByURL returned error: %v", err)
+	}
+	if got := result["proxyCount"]; got != 1 {
+		t.Fatalf("proxyCount = %v, want 1", got)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+}
+
+func TestBrowserProxyFetchClashByURLAllFallbackErrorsHideURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	rawURL := server.URL + "/sub/path?token=secret-token"
+	_, err := (&App{}).BrowserProxyFetchClashByURL(rawURL)
+	if err == nil {
+		t.Fatal("BrowserProxyFetchClashByURL returned nil error, want failure")
+	}
+	errText := err.Error()
+	for _, forbidden := range []string{rawURL, "secret-token", "token=", "/sub/path"} {
+		if strings.Contains(errText, forbidden) {
+			t.Fatalf("error %q leaked %q", errText, forbidden)
+		}
+	}
+}


### PR DESCRIPTION
﻿## 中文说明

### Summary

这个 PR 修复了一类 Clash 订阅 URL 导入失败的问题。

有些订阅服务会根据请求里的 User-Agent 判断客户端类型。之前 AntBrowser 在获取 Clash 订阅时使用固定的 User-Agent，对于部分订阅服务，可能会被拒绝，或者拿到 HTML 错误页、空内容、普通错误文本等无效内容，最终前端表现为“URL 获取失败”。

实际测试中，同一个订阅链接在 FlClash 中可以正常导入，因此这里更像是订阅下载阶段的客户端兼容性问题，而不是 Clash YAML 解析逻辑本身的问题。

这个 PR 没有直接把原来的 User-Agent 替换成 FlClash，而是保留原有 User-Agent 作为第一次尝试，并在失败时自动尝试几个常见的 Clash 类客户端 User-Agent，以尽量减少对已有可用订阅源的影响。

### Changes

- 为 Clash 订阅 URL 下载增加 User-Agent fallback。
- 保留原来的 `clash-verge/2.0 ant-chrome/1.0` 作为第一优先级。
- 当第一次请求失败时，再尝试 FlClash / Clash 兼容的 User-Agent。
- 将原来的单次下载逻辑拆成更清晰的 fallback 下载流程。
- 以下情况会触发下一次 fallback：
  - 网络错误、TLS 错误或超时；
  - HTTP 非 2xx 状态码；
  - body 读取失败；
  - 返回内容为空；
  - 返回 HTML 错误页；
  - 返回普通错误文本；
  - 返回内容无法作为 Clash 订阅内容正常规范化。
- 保留原有请求头，例如 `Accept` 和 `Cache-Control`。
- 所有 User-Agent 都失败时，返回安全的错误信息，不把完整订阅 URL 拼进错误文本。

### Tests

自动测试：

```powershell
go clean -testcache
go test ./backend -run "TestBrowserProxyFetchClashByURL|Test.*Clash"
```

结果：

```text
ok   ant-chrome/backend
```

新增测试覆盖了：

* 第一个 User-Agent 返回 `403`，fallback 到下一个 User-Agent 后成功；
* 第一个 User-Agent 返回 `200 OK` 但内容是 HTML 错误页，fallback 后成功；
* 所有 fallback 都失败时，错误信息不包含完整 URL 或 token；
* 请求仍然携带必要的 `Accept` 和 `Cache-Control` 头。

人工测试也已完成：

* 原本会提示“URL 获取失败”的 Clash 订阅 URL 现在可以成功导入；
* 原本可以正常导入的 Clash 订阅 URL 仍然可以正常导入；
* 故意错误的订阅 URL 会正常失败；
* 未发现 AnyTLS 相关功能回归。

## English explanation

### Summary

This PR fixes a Clash subscription URL import issue caused by User-Agent compatibility.

Some subscription providers check the client type based on the request User-Agent. AntBrowser previously used a fixed User-Agent when fetching Clash subscription URLs. For some providers, this could lead to rejected requests or invalid responses such as HTML error pages, empty bodies, or plain text error messages. In the UI this shows up as “URL 获取失败”.

The same subscription URL was verified to work in clients such as FlClash, so the issue appears to be related to download-time client compatibility rather than the Clash YAML parser itself.

Instead of replacing the existing User-Agent with a FlClash one, this PR keeps the current AntBrowser User-Agent as the first attempt and only falls back to other Clash-compatible User-Agent values when the first attempt fails. This keeps the change safer for subscriptions that already work today.

### Changes

* Add User-Agent fallback for Clash subscription URL downloads.
* Keep the existing `clash-verge/2.0 ant-chrome/1.0` User-Agent as the first attempt.
* Retry with FlClash / Clash-compatible User-Agent values when the previous attempt fails.
* Refactor the single-request download path into a clearer fallback-based flow.
* Trigger fallback for:

  * network errors, TLS errors, or timeouts;
  * non-2xx HTTP responses;
  * body read failures;
  * empty response bodies;
  * HTML error pages;
  * plain text error responses;
  * content that cannot be normalized as a Clash subscription.
* Preserve existing request headers such as `Accept` and `Cache-Control`.
* Return safe error messages when all attempts fail, without embedding the full subscription URL in the error text.

### Tests

Automated tests:

```powershell
go clean -testcache
go test ./backend -run "TestBrowserProxyFetchClashByURL|Test.*Clash"
```

Result:

```text
ok   ant-chrome/backend
```

The added tests cover:

* first User-Agent returns `403`, then fallback succeeds with the next User-Agent;
* first User-Agent returns `200 OK` with an HTML error page, then fallback succeeds;
* all fallback attempts fail without leaking the full URL or token in the error message;
* required request headers such as `Accept` and `Cache-Control` are still sent.

Manual testing was also completed:

* A Clash subscription URL that previously failed with “URL 获取失败” now imports successfully.
* Clash subscription URLs that already worked before still import successfully.
* An intentionally invalid subscription URL still fails as expected.
* No AnyTLS-related regression was observed.
