### PR TITLE
ci: add Arch Linux package build workflow

### DIFF
--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -1,0 +1,150 @@
+name: Build Arch Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Optional package version override, for example 1.2.0
+        required: false
+        type: string
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - .github/workflows/build-arch.yml
+      - packaging/arch/**
+      - backend/**
+      - frontend/**
+      - bin/linux-amd64/**
+      - build/appicon.png
+      - chrome/README.md
+      - go.mod
+      - go.sum
+      - main.go
+      - publish/config.init.linux.yaml
+      - tools/runtime/**
+      - wails.json
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Arch x86_64 package
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Install checkout tools
+        run: |
+          set -euo pipefail
+          pacman -Syu --noconfirm --needed git nodejs
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          pacman -S --noconfirm --needed \
+            git \
+            go \
+            gtk3 \
+            namcap \
+            nodejs \
+            npm \
+            pkgconf \
+            python \
+            webkit2gtk-4.1
+
+      - name: Prepare package version
+        run: |
+          set -euo pipefail
+          version="${{ github.event.inputs.version || '' }}"
+          if [[ -z "$version" ]]; then
+            version="$(python3 - <<'PY'
+          import json
+          with open("wails.json", "r", encoding="utf-8") as f:
+              data = json.load(f)
+          print((((data or {}).get("info") or {}).get("productVersion") or "").strip())
+          PY
+          )"
+          fi
+          if [[ -z "$version" ]]; then
+            echo "Package version is empty" >&2
+            exit 1
+          fi
+          python3 - "$version" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          version = sys.argv[1]
+          path = pathlib.Path("packaging/arch/PKGBUILD")
+          text = path.read_text(encoding="utf-8")
+          text = re.sub(r"^pkgver=.*$", f"pkgver={version}", text, count=1, flags=re.M)
+          path.write_text(text, encoding="utf-8")
+          PY
+          echo "ANT_BROWSER_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Create build user
+        run: |
+          set -euo pipefail
+          useradd -m -s /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+
+      - name: Install Wails CLI
+        run: |
+          set -euo pipefail
+          runuser -u builder -- bash -lc "go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0"
+          runuser -u builder -- bash -lc "~/go/bin/wails version"
+
+      - name: Verify bundled runtimes
+        run: |
+          set -euo pipefail
+          runuser -u builder -- bash -lc "cd '$GITHUB_WORKSPACE' && bash tools/runtime/verify-runtime.sh linux-amd64"
+
+      - name: Build frontend
+        run: |
+          set -euo pipefail
+          runuser -u builder -- bash -lc "cd '$GITHUB_WORKSPACE/frontend' && BROWSERSLIST_IGNORE_OLD_DATA=1 npm ci --prefer-offline --no-audit --no-fund"
+          runuser -u builder -- bash -lc "cd '$GITHUB_WORKSPACE/frontend' && BROWSERSLIST_IGNORE_OLD_DATA=1 npm run build:clean"
+
+      - name: Build Wails binary
+        run: |
+          set -euo pipefail
+          runuser -u builder -- bash -lc "cd '$GITHUB_WORKSPACE' && PATH=\"\$HOME/go/bin:\$PATH\" wails build -s -m -skipbindings -platform linux/amd64 -o ant-chrome -tags webkit2_41"
+          test -x build/bin/ant-chrome
+          ldd build/bin/ant-chrome | tee /tmp/ant-browser-ldd.txt
+          if grep -q "not found" /tmp/ant-browser-ldd.txt; then
+            exit 1
+          fi
+          grep -q "libwebkit2gtk-4.1" /tmp/ant-browser-ldd.txt
+
+      - name: Build Arch package
+        run: |
+          set -euo pipefail
+          install -d -o builder -g builder publish/output
+          runuser -u builder -- bash -lc "cd '$GITHUB_WORKSPACE/packaging/arch' && PKGDEST='$GITHUB_WORKSPACE/publish/output' makepkg -f -C --clean --noconfirm"
+
+      - name: Validate Arch package
+        run: |
+          set -euo pipefail
+          pkg_file="$(ls -1 publish/output/ant-browser-${ANT_BROWSER_VERSION}-*-x86_64.pkg.tar.zst | head -n 1)"
+          echo "Validating: $pkg_file"
+          pacman -Qpi "$pkg_file"
+          pacman -Qlp "$pkg_file" >/dev/null
+          namcap packaging/arch/PKGBUILD "$pkg_file"
+
+      - name: Upload Arch package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ant-browser-arch-x86_64
+          path: publish/output/ant-browser-*-x86_64.pkg.tar.zst
+          if-no-files-found: error

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -54,14 +54,39 @@ jobs:
           set -euo pipefail
           pacman -S --noconfirm --needed \
             git \
+            at-spi2-core \
+            cairo \
+            gdk-pixbuf2 \
             go \
+            glibc \
+            glib2 \
             gtk3 \
+            harfbuzz \
+            hicolor-icon-theme \
+            libnotify \
+            libsoup3 \
+            libx11 \
+            libxcb \
+            libxcomposite \
+            libxcursor \
+            libxdamage \
+            libxext \
+            libxfixes \
+            libxi \
+            libxrandr \
+            libxrender \
+            mesa \
             namcap \
+            nspr \
+            nss \
             nodejs \
             npm \
+            pango \
             pkgconf \
             python \
-            webkit2gtk-4.1
+            webkit2gtk-4.1 \
+            xdg-utils \
+            zlib
 
       - name: Prepare package version
         run: |

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,107 @@
+# Maintainer: Ant Browser Team <contact@antblack.de>
+pkgname=ant-browser
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="Multi-profile browser launcher with proxy-pool management"
+arch=('x86_64')
+url="https://github.com/black-ant/Ant-Browser"
+license=('LicenseRef-Ant-Browser')
+depends=(
+  'at-spi2-core'
+  'cairo'
+  'gdk-pixbuf2'
+  'glibc'
+  'glib2'
+  'gtk3'
+  'harfbuzz'
+  'hicolor-icon-theme'
+  'libnotify'
+  'libsoup3'
+  'libx11'
+  'libxcb'
+  'libxcomposite'
+  'libxcursor'
+  'libxdamage'
+  'libxext'
+  'libxfixes'
+  'libxi'
+  'libxrandr'
+  'libxrender'
+  'mesa'
+  'nspr'
+  'nss'
+  'pango'
+  'webkit2gtk-4.1'
+  'xdg-utils'
+  'zlib'
+)
+makedepends=(
+  'git'
+)
+optdepends=(
+  'xray: external proxy runtime if bundled binary is replaced'
+  'sing-box: external proxy runtime if bundled binary is replaced'
+)
+options=('!strip' '!debug')
+
+_appdir="usr/lib/ant-browser"
+
+package() {
+  local repo_root
+  if [[ -n "${ANT_BROWSER_REPO_ROOT:-}" ]]; then
+    repo_root="$(realpath "${ANT_BROWSER_REPO_ROOT}")"
+  else
+    repo_root="$(git -C "${PWD}" rev-parse --show-toplevel)"
+  fi
+
+  install -Dm755 "${repo_root}/build/bin/ant-chrome" "${pkgdir}/${_appdir}/ant-chrome"
+  install -Dm644 "${repo_root}/publish/config.init.linux.yaml" "${pkgdir}/${_appdir}/config.yaml"
+  install -Dm755 "${repo_root}/bin/linux-amd64/xray" "${pkgdir}/${_appdir}/bin/xray"
+  install -Dm755 "${repo_root}/bin/linux-amd64/sing-box" "${pkgdir}/${_appdir}/bin/sing-box"
+
+  install -dm755 "${pkgdir}/${_appdir}/data" "${pkgdir}/${_appdir}/chrome"
+  touch "${pkgdir}/${_appdir}/data/.keep"
+  install -Dm644 "${repo_root}/chrome/README.md" "${pkgdir}/${_appdir}/chrome/README.md"
+
+  install -Dm644 "${repo_root}/build/appicon.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/ant-browser.png"
+  for size in 16 24 32 48 64 128 256; do
+    install -dm755 "${pkgdir}/usr/share/icons/hicolor/${size}x${size}/apps"
+    ln -s "../../512x512/apps/ant-browser.png" "${pkgdir}/usr/share/icons/hicolor/${size}x${size}/apps/ant-browser.png"
+  done
+  install -dm755 "${pkgdir}/usr/share/pixmaps"
+  ln -s "../icons/hicolor/512x512/apps/ant-browser.png" "${pkgdir}/usr/share/pixmaps/ant-browser.png"
+
+  install -dm755 "${pkgdir}/usr/bin" "${pkgdir}/usr/share/applications" "${pkgdir}/usr/share/metainfo"
+  ln -s "/${_appdir}/ant-chrome" "${pkgdir}/usr/bin/ant-browser"
+  ln -s "/${_appdir}/ant-chrome" "${pkgdir}/usr/bin/ant-chrome"
+
+  cat > "${pkgdir}/usr/share/applications/ant-browser.desktop" <<'EOF'
+[Desktop Entry]
+Version=1.0
+Name=Ant Browser
+Comment=Multi-profile browser launcher with proxy-pool management
+Exec=/usr/lib/ant-browser/ant-chrome
+TryExec=/usr/lib/ant-browser/ant-chrome
+Icon=ant-browser
+Terminal=false
+Type=Application
+Categories=Network;WebBrowser;
+StartupNotify=true
+EOF
+
+  cat > "${pkgdir}/usr/share/metainfo/ant-browser.metainfo.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>ant-browser</id>
+  <name>Ant Browser</name>
+  <summary>Multi-profile browser launcher with proxy-pool management</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>LicenseRef-Ant-Browser</project_license>
+  <launchable type="desktop-id">ant-browser.desktop</launchable>
+  <url type="homepage">https://github.com/black-ant/Ant-Browser</url>
+</component>
+EOF
+
+  install -Dm644 "${repo_root}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+  install -Dm644 "${repo_root}/README.md" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
## Summary

  Adds an Arch Linux packaging workflow that builds the Wails app with WebKitGTK 4.1, validates the generated package with pacman/namcap, and uploads the `.pkg.tar.zst`
  artifact.

  ## Verification

  - GitHub Actions: `Build Arch Package` passed on run `26958863857`
  - Locally verified with `makepkg`
  - Inspected package metadata and file list with `pacman -Qpi` / `pacman -Qlp`
  - Checked runtime linkage with `ldd`
  - Ran `namcap` on the PKGBUILD and generated package