### PR TITLE
Add Windows portable ZIP packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ Ant Browser 适合以下场景：
 - `bat\dev.bat limited`：在 `live` 基础上为 watcher 与其子进程附加 Windows Job Object 内存限制
 - 如需为依赖下载配置代理，可在启动前设置 `DEV_PROXY_URL`、`DEV_NO_PROXY`、`DEV_GOPROXY`
 
+### Windows 发布打包（源码）
+
+Windows 发布脚本默认保持原有 NSIS 安装包行为，也可以生成便携 ZIP，或一次生成两种产物：
+
+```powershell
+bat\publish.bat -Target WINDOWS -WindowsFormat INSTALLER
+bat\publish.bat -Target WINDOWS -WindowsFormat PORTABLE
+bat\publish.bat -Target WINDOWS -WindowsFormat BOTH
+```
+
+省略 `-WindowsFormat` 时等同于 `INSTALLER`。安装包和便携 ZIP 输出到 `publish\output\`。
+
 ### Linux 发布打包（源码）
 
 Linux 发布脚本位于 `publish/linux/`。

--- a/bat/publish.ps1
+++ b/bat/publish.ps1
@@ -1,6 +1,8 @@
 ﻿param(
     [string]$Target,
-    [string]$Version
+    [string]$Version,
+    [ValidateSet("INSTALLER", "PORTABLE", "BOTH")]
+    [string]$WindowsFormat = "INSTALLER"
 )
 
 Set-StrictMode -Version Latest
@@ -9,9 +11,10 @@ $ErrorActionPreference = "Stop"
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 Set-Location $repoRoot
 
-$script:Version = ""
+$script:ResolvedVersion = ""
 $script:LinuxArch = ""
-$script:WindowsDone = $false
+$script:WindowsInstallerDone = $false
+$script:WindowsPortableDone = $false
 $script:LinuxDone = $false
 
 function Write-Section {
@@ -88,9 +91,9 @@ function Resolve-Version {
 
     $explicit = Get-TrimmedText $ExplicitVersion
     if ($explicit -ne "") {
-        $script:Version = Assert-VersionValue -Value $explicit -Source "传入版本号"
+        $script:ResolvedVersion = Assert-VersionValue -Value $explicit -Source "传入版本号"
         Write-Host "[1/3] 使用传入版本号..."
-        Write-Host "✓ 版本号: $script:Version"
+        Write-Host "✓ 版本号: $script:ResolvedVersion"
         Write-Host ""
         return
     }
@@ -107,8 +110,8 @@ function Resolve-Version {
         throw "无法从 wails.json 读取版本号"
     }
 
-    $script:Version = Assert-VersionValue -Value $resolvedVersion -Source "wails.json productVersion"
-    Write-Host "✓ 版本号: $script:Version"
+    $script:ResolvedVersion = Assert-VersionValue -Value $resolvedVersion -Source "wails.json productVersion"
+    Write-Host "✓ 版本号: $script:ResolvedVersion"
     Write-Host ""
 }
 
@@ -126,15 +129,15 @@ function Invoke-WithTemporaryWailsVersion {
 
     $currentConfig = Get-Content -LiteralPath $wailsConfigPath -Raw | ConvertFrom-Json
     $currentVersion = Get-TrimmedText ([string]$currentConfig.info.productVersion)
-    if ($currentVersion -eq $script:Version) {
+    if ($currentVersion -eq $script:ResolvedVersion) {
         & $ScriptBlock
         return
     }
 
-    Write-Host "  临时覆盖 wails.json productVersion: $currentVersion -> $script:Version"
+    Write-Host "  临时覆盖 wails.json productVersion: $currentVersion -> $script:ResolvedVersion"
     $originalBytes = [System.IO.File]::ReadAllBytes($wailsConfigPath)
     try {
-        $currentConfig.info.productVersion = $script:Version
+        $currentConfig.info.productVersion = $script:ResolvedVersion
         $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
         $jsonText = ($currentConfig | ConvertTo-Json -Depth 100)
         [System.IO.File]::WriteAllText($wailsConfigPath, $jsonText + "`n", $utf8NoBom)
@@ -188,6 +191,19 @@ function Resolve-PublishTarget {
         }
         Write-Host "✗ 未选择有效目标" -ForegroundColor Yellow
     }
+}
+
+function Resolve-WindowsFormat {
+    param([string]$InputFormat)
+
+    $normalized = (Get-TrimmedText $InputFormat).ToUpperInvariant()
+    if ($normalized -eq "") {
+        return "INSTALLER"
+    }
+    if ($normalized -notin @("INSTALLER", "PORTABLE", "BOTH")) {
+        throw "无效的 Windows 输出格式: $InputFormat`n  支持参数: INSTALLER/PORTABLE/BOTH"
+    }
+    return $normalized
 }
 
 function Resolve-NsisPath {
@@ -505,7 +521,7 @@ function Invoke-WindowsPackaging {
         Write-Host "  NSIS 全局配置: disabled (/NOCONFIG)"
     }
     $nsisArguments = @(
-        "/DVERSION=$script:Version",
+        "/DVERSION=$script:ResolvedVersion",
         "/DSTAGINGDIR=$stagingAbs",
         "publish\installer.nsi"
     )
@@ -521,6 +537,83 @@ function Invoke-WindowsPackaging {
     Write-Host ""
 }
 
+function New-WindowsPortableArchive {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StagingDir
+    )
+
+    Write-Host "[Windows] 生成便携 ZIP..."
+    $outputDir = Join-Path $repoRoot "publish/output"
+    if (-not (Test-Path -LiteralPath $outputDir)) {
+        New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+    }
+
+    $archiveName = "AntBrowser-$script:ResolvedVersion-windows-amd64-portable.zip"
+    $archivePath = Join-Path $outputDir $archiveName
+    $rootName = "AntBrowser-$script:ResolvedVersion-windows-amd64-portable"
+    if (Test-Path -LiteralPath $archivePath) {
+        Remove-Item -LiteralPath $archivePath -Force
+    }
+
+    Add-Type -AssemblyName System.IO.Compression
+    $archiveStream = [System.IO.File]::Open(
+        $archivePath,
+        [System.IO.FileMode]::CreateNew,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None
+    )
+    try {
+        $archive = New-Object System.IO.Compression.ZipArchive(
+            $archiveStream,
+            [System.IO.Compression.ZipArchiveMode]::Create,
+            $false
+        )
+        try {
+            $archive.CreateEntry("$rootName/") | Out-Null
+
+            foreach ($directory in (Get-ChildItem -LiteralPath $StagingDir -Directory -Recurse -Force)) {
+                $relativePath = $directory.FullName.Substring($StagingDir.Length).TrimStart('\', '/')
+                $entryName = "$rootName/$($relativePath.Replace('\', '/'))/"
+                $archive.CreateEntry($entryName) | Out-Null
+            }
+
+            foreach ($file in (Get-ChildItem -LiteralPath $StagingDir -File -Recurse -Force)) {
+                $relativePath = $file.FullName.Substring($StagingDir.Length).TrimStart('\', '/')
+                $entryName = "$rootName/$($relativePath.Replace('\', '/'))"
+                $entry = $archive.CreateEntry(
+                    $entryName,
+                    [System.IO.Compression.CompressionLevel]::Optimal
+                )
+                $inputStream = [System.IO.File]::OpenRead($file.FullName)
+                $outputStream = $entry.Open()
+                try {
+                    $inputStream.CopyTo($outputStream)
+                }
+                finally {
+                    $outputStream.Dispose()
+                    $inputStream.Dispose()
+                }
+            }
+        }
+        finally {
+            $archive.Dispose()
+        }
+    }
+    finally {
+        $archiveStream.Dispose()
+    }
+
+    if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) {
+        throw "便携 ZIP 生成失败: $archivePath"
+    }
+
+    $script:WindowsPortableDone = $true
+    Write-Host "✓ Windows 便携包生成成功: publish\output\$archiveName"
+    Write-Host ""
+    return $archivePath
+}
+
 function Remove-WindowsStaging {
     param([string]$StagingDir)
 
@@ -533,23 +626,37 @@ function Remove-WindowsStaging {
 }
 
 function Publish-Windows {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Format
+    )
+
     Write-Host "[3/3] 开始 Windows 打包..."
+    Write-Host "  输出格式: $Format"
     Write-Host ""
 
-    $makensisPath = Resolve-NsisPath
+    $makensisPath = $null
+    if ($Format -in @("INSTALLER", "BOTH")) {
+        $makensisPath = Resolve-NsisPath
+    }
     Assert-RuntimeHashes -Target "windows-amd64"
     Build-WindowsBinary
 
     $stagingDir = $null
     try {
         $stagingDir = New-WindowsStaging
-        Invoke-WindowsPackaging -MakensisPath $makensisPath -StagingDir $stagingDir
+        if ($Format -in @("INSTALLER", "BOTH")) {
+            Invoke-WindowsPackaging -MakensisPath $makensisPath -StagingDir $stagingDir
+            $script:WindowsInstallerDone = $true
+        }
+        if ($Format -in @("PORTABLE", "BOTH")) {
+            New-WindowsPortableArchive -StagingDir $stagingDir | Out-Null
+        }
     }
     finally {
         Remove-WindowsStaging -StagingDir $stagingDir
     }
 
-    $script:WindowsDone = $true
     Write-Host "✓ Windows 打包完成"
     Write-Host ""
 }
@@ -565,7 +672,7 @@ function Publish-Linux {
     }
 
     try {
-        & powershell -NoProfile -ExecutionPolicy Bypass -File $linuxScript -RepoRoot $repoRoot -ArchOutFile $archOutFile -Version $script:Version
+        & powershell -NoProfile -ExecutionPolicy Bypass -File $linuxScript -RepoRoot $repoRoot -ArchOutFile $archOutFile -Version $script:ResolvedVersion
         if ($LASTEXITCODE -ne 0) {
             throw "Linux 打包失败"
         }
@@ -591,17 +698,18 @@ try {
 
     Resolve-Version -ExplicitVersion $Version
     $publishTarget = Resolve-PublishTarget -InputTarget $Target
+    $resolvedWindowsFormat = Resolve-WindowsFormat -InputFormat $WindowsFormat
 
     Invoke-WithTemporaryWailsVersion {
         switch ($publishTarget) {
             "WINDOWS" {
-                Publish-Windows
+                Publish-Windows -Format $resolvedWindowsFormat
             }
             "LINUX" {
                 Publish-Linux
             }
             "BOTH" {
-                Publish-Windows
+                Publish-Windows -Format $resolvedWindowsFormat
                 Publish-Linux
             }
             default {
@@ -613,8 +721,11 @@ try {
     Write-Host ""
     Write-Section "✓ 发布完成！"
     Write-Host ""
-    if ($script:WindowsDone) {
-        Write-Host "Windows 安装包: publish\output\AntBrowser-Setup-$script:Version.exe"
+    if ($script:WindowsInstallerDone) {
+        Write-Host "Windows 安装包: publish\output\AntBrowser-Setup-$script:ResolvedVersion.exe"
+    }
+    if ($script:WindowsPortableDone) {
+        Write-Host "Windows 便携包: publish\output\AntBrowser-$script:ResolvedVersion-windows-amd64-portable.zip"
     }
     if ($script:LinuxDone) {
         Write-Host "Linux 产物目录: publish\output\"


### PR DESCRIPTION
## 中文说明

### 为什么做这个改动

我注意到项目当前的 Windows 发布流程主要生成 NSIS 格式的 `.exe` 安装程序。

安装方式本身很好，不过在一些使用场景下，直接下载 ZIP、解压后运行可能会更加方便，例如免安装使用、放在移动硬盘中运行，或者保留多份彼此独立的程序目录。

目前官方发布流程中还没有直接生成完整便携 ZIP 的选项，所以我在现有 Windows 发布脚本的基础上补充了这一种输出方式。

如果作者觉得这个方案合适，后续发布时可以按实际需要选择生成安装程序、便携 ZIP，或者同时生成两种产物，或许能让后续发布和使用更加方便。

### 主要改动

本次修改扩展了现有的：

```text
bat/publish.ps1
```

增加了三种 Windows 输出格式：

```text
INSTALLER
PORTABLE
BOTH
```

只生成原有的 NSIS 安装程序：

```powershell
powershell -File bat/publish.ps1 -Target WINDOWS -WindowsFormat INSTALLER
```

只生成便携 ZIP：

```powershell
powershell -File bat/publish.ps1 -Target WINDOWS -WindowsFormat PORTABLE
```

同时生成安装程序和便携 ZIP：

```powershell
powershell -File bat/publish.ps1 -Target WINDOWS -WindowsFormat BOTH
```

不填写 `-WindowsFormat` 时，默认仍然是 `INSTALLER`，不会改变原来的发布方式。

### 便携包内容

生成的文件路径为：

```text
publish/output/AntBrowser-{version}-windows-amd64-portable.zip
```

压缩包中包含运行所需的主要文件：

```text
AntBrowser-{version}-windows-amd64-portable/
├─ ant-chrome.exe
├─ config.yaml
├─ bin/
│  ├─ xray.exe
│  └─ sing-box.exe
├─ chrome/
└─ data/
```

便携 ZIP 直接复用原有的 Windows staging 流程，因此安装包和便携包使用相同的主程序、初始配置、Xray 和 sing-box 运行时，以及浏览器内核处理逻辑。

压缩包不会包含用户数据库、浏览器实例、代理订阅或其他个人数据。

`PORTABLE` 模式不需要 NSIS；`BOTH` 模式只构建一次程序并准备一次 staging。

### 验证情况

已经完成以下验证：

* PowerShell 脚本语法检查通过；
* Windows 主程序构建成功；
* 便携 ZIP 成功生成并解压；
* `ant-chrome.exe`、`xray.exe` 和 `sing-box.exe` 均正确包含；
* `config.yaml` 与官方初始配置模板一致；
* ZIP 中没有用户数据库、个人配置、源码或其他平台的运行时；
* 将 ZIP 移动到桌面并独立解压后，`ant-chrome.exe` 可以正常启动；
* 程序运行不依赖原来的源码目录；
* 测试产物已经清理，没有提交到仓库。

---

## English Description

### Motivation

I noticed that the current Windows publishing flow mainly produces an NSIS `.exe` installer.

The installer itself works well, but in some situations a ZIP archive that can be extracted and run directly may be more convenient, for example for no-install usage, removable drives, or keeping multiple independent application directories.

The current upstream publishing flow does not provide an option to generate a complete portable ZIP directly, so this PR adds that output option to the existing Windows publishing script.

If the maintainer finds the approach useful, future releases can choose to generate the installer, the portable ZIP, or both, depending on the release needs.

### Changes

This PR extends the existing:

```text
bat/publish.ps1
```

script with three Windows output formats:

```text
INSTALLER
PORTABLE
BOTH
```

Generate only the existing NSIS installer:

```powershell
powershell -File bat/publish.ps1 -Target WINDOWS -WindowsFormat INSTALLER
```

Generate only the portable ZIP:

```powershell
powershell -File bat/publish.ps1 -Target WINDOWS -WindowsFormat PORTABLE
```

Generate both outputs:

```powershell
powershell -File bat/publish.ps1 -Target WINDOWS -WindowsFormat BOTH
```

When `-WindowsFormat` is omitted, the default remains `INSTALLER`, preserving the existing publishing behavior.

### Portable package contents

The archive is written to:

```text
publish/output/AntBrowser-{version}-windows-amd64-portable.zip
```

It contains the main runtime files:

```text
AntBrowser-{version}-windows-amd64-portable/
├─ ant-chrome.exe
├─ config.yaml
├─ bin/
│  ├─ xray.exe
│  └─ sing-box.exe
├─ chrome/
└─ data/
```

The portable ZIP reuses the existing Windows staging flow, so the installer and portable package use the same application executable, initial configuration, Xray and sing-box runtimes, and browser runtime handling logic.

The archive does not include user databases, browser profiles, proxy subscriptions, or other personal data.

`PORTABLE` mode does not require NSIS. `BOTH` mode builds the application and prepares staging only once.

### Verification

The following checks were completed:

* PowerShell syntax validation passed;
* the Windows application was built successfully;
* the portable ZIP was generated and extracted successfully;
* `ant-chrome.exe`, `xray.exe`, and `sing-box.exe` were included correctly;
* the packaged `config.yaml` matched the official initial configuration template;
* no user databases, personal configuration, source files, or wrong-platform runtimes were included;
* the ZIP was moved to the desktop and extracted independently of the source tree;
* `ant-chrome.exe` launched successfully from the extracted directory;
* the application did not depend on the original source directory;
* all generated test artifacts were removed and were not committed.