### PR TITLE
fix: persist scanned browser cores

### DIFF
--- a/backend/app_browser_core_scan_test.go
+++ b/backend/app_browser_core_scan_test.go
@@ -1,0 +1,84 @@
+package backend
+
+import (
+	"ant-chrome/backend/internal/browser"
+	"ant-chrome/backend/internal/config"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type browserCoreDAOStub struct {
+	list []browser.Core
+}
+
+func (s *browserCoreDAOStub) List() ([]browser.Core, error) {
+	return append([]browser.Core{}, s.list...), nil
+}
+
+func (s *browserCoreDAOStub) Upsert(core browser.Core) error {
+	for i := range s.list {
+		if s.list[i].CoreId == core.CoreId {
+			s.list[i] = core
+			return nil
+		}
+	}
+	s.list = append(s.list, core)
+	return nil
+}
+
+func (s *browserCoreDAOStub) Delete(coreId string) error {
+	next := s.list[:0]
+	for _, core := range s.list {
+		if core.CoreId != coreId {
+			next = append(next, core)
+		}
+	}
+	s.list = next
+	return nil
+}
+
+func (s *browserCoreDAOStub) SetDefault(coreId string) error {
+	for i := range s.list {
+		s.list[i].IsDefault = s.list[i].CoreId == coreId
+	}
+	return nil
+}
+
+func TestBrowserCoreScanRegistersDetectedCoreInDAO(t *testing.T) {
+	root := t.TempDir()
+	coreDir := filepath.Join(root, "chrome", "chromium-148")
+	exePath := filepath.Join(coreDir, filepath.FromSlash(browser.CoreExecutableCandidates()[0]))
+	if err := os.MkdirAll(filepath.Dir(exePath), 0o755); err != nil {
+		t.Fatalf("创建测试内核目录失败: %v", err)
+	}
+	if err := os.WriteFile(exePath, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("写入测试内核可执行文件失败: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Browser.Cores = nil
+
+	app := NewApp(root)
+	app.config = cfg
+	app.browserMgr = browser.NewManager(cfg, root)
+	dao := &browserCoreDAOStub{}
+	app.browserMgr.CoreDAO = dao
+
+	cores := app.BrowserCoreScan()
+	if len(dao.list) != 1 {
+		t.Fatalf("扫描后应写入 DAO 1 个内核，got=%d", len(dao.list))
+	}
+	if dao.list[0].CoreId != "core-chromium-148" {
+		t.Fatalf("内核 ID 不符合预期: got=%q", dao.list[0].CoreId)
+	}
+	if dao.list[0].CorePath != filepath.Join("chrome", "chromium-148") {
+		t.Fatalf("内核路径不符合预期: got=%q", dao.list[0].CorePath)
+	}
+	if !dao.list[0].IsDefault {
+		t.Fatal("首个扫描到的内核应设为默认")
+	}
+	if len(cores) != 1 || cores[0].CoreId != dao.list[0].CoreId {
+		t.Fatalf("扫描返回列表未包含新内核: %+v", cores)
+	}
+}

--- a/backend/app_utils.go
+++ b/backend/app_utils.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -58,7 +59,7 @@ func (a *App) ensureDefaultCores() {
 	log := logger.New("Browser")
 
 	// 扫描 chrome/ 目录，无论配置是否已有内核都执行一次，确保新增子目录被发现
-	detected := a.scanChromeDir("chrome")
+	detected := a.scanChromeDir(a.browserCoreRoot())
 
 	if len(a.config.Browser.Cores) == 0 {
 		// 配置为空：直接用扫描结果，或兜底写一个占位
@@ -100,9 +101,8 @@ func (a *App) ensureDefaultCores() {
 
 func (a *App) autoDetectCores() {
 	log := logger.New("Browser")
-	// ensureDefaultCores 已完成扫描注册，这里只做路径有效性日志。
+	cores := a.scanAndRegisterCores()
 	// SQLite 模式下以内核表为准，避免与 config.yaml 历史条目不一致。
-	cores := a.config.Browser.Cores
 	if a.browserMgr != nil {
 		cores = a.browserMgr.ListCores()
 	}
@@ -114,6 +114,61 @@ func (a *App) autoDetectCores() {
 			log.Warn("内核路径无效", logger.F("core_id", core.CoreId), logger.F("path", core.CorePath), logger.F("message", result.Message))
 		}
 	}
+}
+
+func (a *App) browserCoreRoot() string {
+	if a != nil && a.config != nil {
+		if root := strings.TrimSpace(a.config.Browser.CoreRoot); root != "" {
+			return root
+		}
+	}
+	return "chrome"
+}
+
+func (a *App) scanAndRegisterCores() []browser.Core {
+	log := logger.New("Browser")
+	detected := a.scanChromeDir(a.browserCoreRoot())
+	if len(detected) == 0 || a.browserMgr == nil {
+		return detected
+	}
+
+	existing := a.browserMgr.ListCores()
+	knownPaths := make(map[string]struct{}, len(existing))
+	hasDefault := false
+	for _, core := range existing {
+		knownPaths[normalizeCorePathForCompare(core.CorePath)] = struct{}{}
+		if core.IsDefault {
+			hasDefault = true
+		}
+	}
+
+	for _, core := range detected {
+		if _, ok := knownPaths[normalizeCorePathForCompare(core.CorePath)]; ok {
+			continue
+		}
+		core.IsDefault = !hasDefault
+		if err := a.browserMgr.SaveCore(browser.CoreInput{
+			CoreId:    core.CoreId,
+			CoreName:  core.CoreName,
+			CorePath:  core.CorePath,
+			IsDefault: core.IsDefault,
+		}); err != nil {
+			log.Warn("自动注册内核失败", logger.F("core_id", core.CoreId), logger.F("path", core.CorePath), logger.F("error", err.Error()))
+			continue
+		}
+		log.Info("发现新内核，已注册", logger.F("core_id", core.CoreId), logger.F("path", core.CorePath))
+		knownPaths[normalizeCorePathForCompare(core.CorePath)] = struct{}{}
+		hasDefault = hasDefault || core.IsDefault
+	}
+	return a.browserMgr.ListCores()
+}
+
+func normalizeCorePathForCompare(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(path))
 }
 
 // scanChromeDir 扫描指定目录，将包含浏览器可执行文件的子文件夹识别为内核。


### PR DESCRIPTION
### 背景 / 问题原因

  当前“扫描内核”功能存在一个实际未生效的问题：扫描逻辑可以发现 `chrome/` 目录下的浏览器内
  核，但没有通过浏览器管理器写入 SQLite 的 `browser_cores` 表。因此前端触发“扫描内核”后，
  界面/数据库中不会真正新增可用内核。

  这个问题在特定环境下更容易暴露，例如 Linux + NixOS：

  - 软件安装目录位于 `/nix/store/.../lib/ant-browser`，运行时是只读的。
  - 应用检测到安装目录不可写后，会自动把运行状态目录降级到 `$HOME/.local/share/ant-
  browser`。
  - SQLite 数据库实际位于 `$HOME/.local/share/ant-browser/data/app.db`。
  - 此时内核扫描如果只更新内存或配置文件，而不写入 SQLite，就会导致手动扫描没有任何实际效
  果。

  在其他环境下，这个问题可能被掩盖。例如安装目录可写时，应用可能通过安装目录下的
  `config.yaml`、`data/app.db`，或已有的 `browser.cores` 配置完成内核初始化/迁移；或者用户
  手动配置过内核路径后，数据库中已经存在记录，因此不会明显暴露“扫描后未持久化”的问题。

  ### 修改内容

  - 让自动扫描逻辑使用配置中的 `browser.core_root`，而不是固定扫描 `chrome`。
  - 扫描到新内核后，通过 `browserMgr.SaveCore` 写入 SQLite。
  - 通过规范化后的 core path 避免重复注册同一个内核。
  - 保留已有默认内核逻辑：如果当前没有默认内核，则把第一个扫描到的内核设为默认。
  - 增加回归测试，验证 `BrowserCoreScan` 能把扫描到的内核写入 DAO。
  - 简化 Wails `frontend:install`，避免 Wails 将 `&&` 当作 npm package tag 解析。

  ### 验证

  go test ./backend/...

  ———

  ## English Description

  ### Background / Root Cause

  The current browser core scan feature can detect browser cores under the chrome/
  directory, but the detected cores are not persisted into the SQLite browser_cores table
  through the browser manager. As a result, triggering “Scan Cores” from the frontend does
  not actually register any new usable browser core.

  This is especially visible in environments such as Linux + NixOS:

  - The application is installed under a read-only path like /nix/store/.../lib/ant-
    browser.
  - At startup, the app detects the read-only install directory and falls back to the user
    state directory: $HOME/.local/share/ant-browser.
  - The SQLite database is then stored at $HOME/.local/share/ant-browser/data/app.db.
  - If scanning only updates memory/config state but does not persist to SQLite, manual
    core scanning has no real effect.

  In other environments, this issue can be masked. For example, when the install directory
  is writable, the app may initialize or migrate browser cores through config.yaml, data/
  app.db, or existing browser.cores entries. If users have already configured a core path
  manually, the database may already contain a valid core record, making the broken scan
  behavior less obvious.

  ### Changes

  - Use configured browser.core_root instead of always scanning chrome.
  - Persist newly detected cores through browserMgr.SaveCore.
  - Avoid duplicate core registration by comparing normalized core paths.
  - Preserve default-core behavior by marking the first detected core as default when no
    default exists.
  - Add a regression test to verify that BrowserCoreScan persists detected cores into the
    DAO.
  - Simplify Wails frontend:install to avoid Wails passing && as an npm package tag.

  ### Test

  go test ./backend/...