### PR TITLE
fix: support authenticated socks5/http proxies

### DIFF
--- a/backend/internal/proxy/kernel_resolver.go
+++ b/backend/internal/proxy/kernel_resolver.go
@@ -117,7 +117,15 @@ func DetectProxyProtocol(proxyConfig string) string {
 
 func SupportedKernelsForProtocol(protocol string, proxyConfig string, proxies []config.BrowserProxy, proxyId string) []string {
 	switch strings.ToLower(strings.TrimSpace(protocol)) {
-	case "direct", "http", "https", "socks5":
+	case "direct":
+		return []string{ProxyKernelNative}
+	case "http", "https", "socks5":
+		// 带账号密码鉴权的 socks5/http 代理：Chromium 的 --proxy-server 无法携带凭据，
+		// 浏览器 native 会静默丢弃鉴权信息导致连接失败。这类代理必须通过 xray / mihomo
+		// 桥接成本地无鉴权 socks5 再交给浏览器。无鉴权的代理仍走 native。
+		if RequiresLocalProxyBridgeForBrowser(proxyConfig) {
+			return []string{ProxyKernelXray, ProxyKernelMihomo}
+		}
 		return []string{ProxyKernelNative}
 	case "vmess", "vless", "trojan", "ss", "shadowsocks", "chain+socks5":
 		return []string{ProxyKernelXray, ProxyKernelMihomo}

--- a/backend/internal/proxy/kernel_resolver_test.go
+++ b/backend/internal/proxy/kernel_resolver_test.go
@@ -17,6 +17,9 @@ func TestResolveProxyKernelDefaultPriority(t *testing.T) {
 		{name: "anytls URI uses sing-box", proxy: "anytls://pass@example.com:443?sni=example.com", wantKernel: ProxyKernelSingBox},
 		{name: "mieru uses mihomo", proxy: mieruClashNode, wantKernel: ProxyKernelMihomo},
 		{name: "http uses native", proxy: "http://127.0.0.1:8080", wantKernel: ProxyKernelNative},
+		{name: "socks5 without auth uses native", proxy: "socks5://127.0.0.1:1080", wantKernel: ProxyKernelNative},
+		{name: "socks5 with auth uses xray", proxy: "socks5://user:pass@127.0.0.1:1080", wantKernel: ProxyKernelXray},
+		{name: "http with auth uses xray", proxy: "http://user:pass@127.0.0.1:8080", wantKernel: ProxyKernelXray},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Chromium 的 --proxy-server 无法携带凭据，导致导入带鉴权的
socks5://user:pass@host:port 代理时chrome浏览器静默丢弃鉴权而连接失败。

内核选择器原先将所有 socks5/http 一律固定为 native，不能使用 xray/mihomo。

现改为：带鉴权的 socks5/http 自动使用 xray/mihomo 代理为本地无鉴权 socks5 再交给浏览器；无鉴权
代理仍走 native。

<img width="1246" height="208" alt="image" src="https://github.com/user-attachments/assets/a07b8fe5-27e0-45a9-bf90-3e79883fc88a" />
