### PR TITLE
fix: use StateRoot for backup export and make dev.sh work on macOS

### DIFF
--- a/backend/app_backup_entry.go
+++ b/backend/app_backup_entry.go
@@ -48,7 +48,8 @@ func (a *App) BackupExportPackage() (map[string]interface{}, error) {
 	savePath = backupEnsureZipSuffix(savePath)
 	a.backupEmitExportProgress("preparing", 8, "正在收集导出范围...")
 
-	scope, err := backup.BuildScope(backup.BuildOptions{AppRoot: a.appRoot, Config: a.config})
+	// 必须与 BackupGetScopeDefinition 一致：detached 模式下使用 StateRoot，不能用安装根 a.appRoot。
+	scope, err := a.BackupGetScopeDefinition()
 	if err != nil {
 		a.backupEmitExportProgress("error", 100, fmt.Sprintf("导出失败: %v", err))
 		return nil, err

--- a/dev.sh
+++ b/dev.sh
@@ -21,13 +21,18 @@ require_cmd() {
   local cmd="$1"
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "[ERROR] Missing required command: $cmd" >&2
-    exit 1
+    return 1
   fi
 }
 
 is_tcp_port_busy() {
   local port="$1"
-  ss -ltn "( sport = :$port )" | tail -n +2 | grep -q .
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltn "( sport = :$port )" | tail -n +2 | grep -q .
+  else
+    # macOS has no ss; fall back to lsof.
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+  fi
 }
 
 resolve_wails_devserver() {
@@ -35,7 +40,7 @@ resolve_wails_devserver() {
   local host="${WAILS_DEVSERVER_HOST:-127.0.0.1}"
   local port="$start_port"
 
-  require_cmd ss
+  require_cmd ss || require_cmd lsof
 
   while is_tcp_port_busy "$port"; do
     port=$((port + 1))


### PR DESCRIPTION
## Summary
- Backup export now reuses `BackupGetScopeDefinition`, which resolves against `apppath.StateRoot` instead of the install root. Fixes macOS `.app` export failures that looked for `Contents/MacOS/data` while writable state lives under Application Support.
- `dev.sh` falls back to `lsof` when `ss` is unavailable so the macOS local launcher can start.

## Test plan
- [ ] On a macOS installed `.app` (detached), run **导出配置** and confirm it succeeds
- [ ] Confirm export ZIP content comes from `~/Library/Application Support/ant-browser` rather than `.app/Contents/MacOS`
- [ ] On macOS, run `bash ./dev.sh` and confirm it no longer fails with `Missing required command: ss`
- [ ] On Linux/Windows portable layout, backup export and `dev.sh` still work as before


Made with [Cursor](https://cursor.com)