### PR TITLE
fix: avoid Wails macOS crash on core import file dialog

### DIFF
--- a/backend/app_browser_config_api.go
+++ b/backend/app_browser_config_api.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
@@ -96,12 +97,15 @@ func (a *App) BrowserCoreImportLocal() (*BrowserCore, error) {
 		return nil, fmt.Errorf("browser manager is nil")
 	}
 
+	filters := []wailsruntime.FileFilter{
+		{DisplayName: "Chrome 内核归档 (" + browser.SupportedCoreArchiveDescription() + ")", Pattern: browser.SupportedCoreArchiveDialogPattern()},
+	}
+	if runtime.GOOS != "darwin" {
+		filters = append(filters, wailsruntime.FileFilter{DisplayName: "所有文件 (*.*)", Pattern: "*.*"})
+	}
 	selectedPath, err := wailsruntime.OpenFileDialog(a.ctx, wailsruntime.OpenDialogOptions{
-		Title: "选择 Chrome 内核归档文件",
-		Filters: []wailsruntime.FileFilter{
-			{DisplayName: "Chrome 内核归档 (" + browser.SupportedCoreArchiveDescription() + ")", Pattern: browser.SupportedCoreArchivePattern()},
-			{DisplayName: "所有文件 (*.*)", Pattern: "*.*"},
-		},
+		Title:   "选择 Chrome 内核归档文件",
+		Filters: filters,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/browser/download_core_extract.go
+++ b/backend/internal/browser/download_core_extract.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/ulikunitz/xz"
@@ -25,6 +26,16 @@ type archiveProgress struct {
 
 func SupportedCoreArchivePattern() string {
 	return "*.zip;*.tar;*.tar.gz;*.tgz;*.tar.xz;*.txz;*.tar.bz2;*.tbz2"
+}
+
+// SupportedCoreArchiveDialogPattern is for OpenFileDialog filters.
+// Wails on macOS maps extensions via UTType and crashes on compound
+// patterns like *.tar.gz or *.*; use single-segment extensions there.
+func SupportedCoreArchiveDialogPattern() string {
+	if runtime.GOOS == "darwin" {
+		return "*.zip;*.tar;*.tgz;*.gz;*.txz;*.xz;*.tbz2;*.bz2"
+	}
+	return SupportedCoreArchivePattern()
 }
 
 func SupportedCoreArchiveDescription() string {


### PR DESCRIPTION
## Summary
- On macOS, Wails maps OpenFileDialog filters through `UTType`; compound patterns like `*.tar.gz` and `*.*` can return nil and crash the app.
- Use a darwin-safe single-segment dialog pattern for local browser core import, and keep the full pattern (plus `*.*`) on Linux/Windows.
- Extraction still accepts the full archive suffix set; only the file picker filters change.

## Test plan
- [ ] On macOS: 内核管理 → 导入本地 opens the file dialog without crashing
- [ ] Import a `.zip` / `.tgz` / `.tar.gz` (via `.gz` filter) and confirm registration still works
- [ ] On Linux/Windows (if available): dialog still shows full patterns including `*.tar.gz` and「所有文件」


Made with [Cursor](https://cursor.com)