### PR TITLE
feat(proxy): support imported nodes as chain front hops

### DIFF
--- a/backend/internal/proxy/chain_proxy.go
+++ b/backend/internal/proxy/chain_proxy.go
@@ -1,0 +1,188 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"ant-chrome/backend/internal/config"
+)
+
+const chainProxyPrefix = "chain+proxy://"
+
+type chainProxyConfig struct {
+	Version       int            `json:"version,omitempty"`
+	FrontProxyID  string         `json:"frontProxyId"`
+	Landing       chainSocks5Hop `json:"landing"`
+	LocalPort     int            `json:"localPort,omitempty"`
+	PreferredCore string         `json:"preferredKernel,omitempty"`
+}
+
+func IsChainProxy(src string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(src)), chainProxyPrefix)
+}
+
+func ParseChainProxyConfig(src string) (*chainProxyConfig, error) {
+	raw := strings.TrimSpace(src)
+	if !IsChainProxy(raw) {
+		return nil, fmt.Errorf("不是通用链式代理配置")
+	}
+	decoded, err := url.QueryUnescape(raw[len(chainProxyPrefix):])
+	if err != nil {
+		return nil, fmt.Errorf("链式代理配置解码失败: %w", err)
+	}
+	var cfg chainProxyConfig
+	if err := json.Unmarshal([]byte(decoded), &cfg); err != nil {
+		return nil, fmt.Errorf("链式代理配置 JSON 解析失败: %w", err)
+	}
+	if strings.TrimSpace(cfg.FrontProxyID) == "" {
+		return nil, fmt.Errorf("请选择前置代理节点")
+	}
+	if err := validateChainSocks5Hop("落地", cfg.Landing); err != nil {
+		return nil, err
+	}
+	if cfg.LocalPort < 0 || cfg.LocalPort > 65535 {
+		return nil, fmt.Errorf("本地监听端口必须在 1-65535 之间")
+	}
+	cfg.Version = 2
+	cfg.FrontProxyID = strings.TrimSpace(cfg.FrontProxyID)
+	cfg.Landing.Protocol = normalizeChainHopProtocol(cfg.Landing.Protocol)
+	return &cfg, nil
+}
+
+func resolveChainFront(cfg *chainProxyConfig, proxies []config.BrowserProxy, currentProxyID string) (config.BrowserProxy, error) {
+	if cfg == nil {
+		return config.BrowserProxy{}, fmt.Errorf("链式代理配置为空")
+	}
+	if strings.EqualFold(cfg.FrontProxyID, strings.TrimSpace(currentProxyID)) {
+		return config.BrowserProxy{}, fmt.Errorf("前置代理不能引用链式代理自身")
+	}
+	for _, item := range proxies {
+		if !strings.EqualFold(strings.TrimSpace(item.ProxyId), cfg.FrontProxyID) {
+			continue
+		}
+		frontSrc := strings.TrimSpace(item.ProxyConfig)
+		if frontSrc == "" || strings.EqualFold(frontSrc, "direct://") {
+			return config.BrowserProxy{}, fmt.Errorf("前置代理 %s 没有可用节点配置", cfg.FrontProxyID)
+		}
+		if IsChainProxy(frontSrc) || IsChainSocks5Proxy(frontSrc) {
+			return config.BrowserProxy{}, fmt.Errorf("前置代理不能再次引用链式代理")
+		}
+		return item, nil
+	}
+	return config.BrowserProxy{}, fmt.Errorf("前置代理节点不存在或已删除: %s", cfg.FrontProxyID)
+}
+
+func chainHopFromStandardProxy(src string) (chainSocks5Hop, error) {
+	parsed, err := url.Parse(strings.TrimSpace(src))
+	if err != nil {
+		return chainSocks5Hop{}, err
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port < 1 || port > 65535 || strings.TrimSpace(parsed.Hostname()) == "" {
+		return chainSocks5Hop{}, fmt.Errorf("代理地址或端口无效")
+	}
+	hop := chainSocks5Hop{Protocol: strings.ToLower(parsed.Scheme), Server: parsed.Hostname(), Port: port}
+	if parsed.User != nil {
+		hop.Username = parsed.User.Username()
+		hop.Password, _ = parsed.User.Password()
+	}
+	hop.TLS = hop.Protocol == "https"
+	return hop, validateChainSocks5Hop("前置", hop)
+}
+
+func buildXrayChainOutbounds(cfg *chainProxyConfig, proxies []config.BrowserProxy, currentProxyID string) ([]interface{}, []interface{}, error) {
+	front, err := resolveChainFront(cfg, proxies, currentProxyID)
+	if err != nil {
+		return nil, nil, err
+	}
+	frontSrc := normalizeNodeScheme(strings.TrimSpace(front.ProxyConfig))
+	var frontOutbound map[string]interface{}
+	protocol := DetectProxyProtocol(frontSrc)
+	if protocol == "http" || protocol == "socks5" {
+		hop, err := chainHopFromStandardProxy(frontSrc)
+		if err != nil {
+			return nil, nil, err
+		}
+		frontOutbound = chainSocks5Outbound(hop, "front-hop", "")
+	} else {
+		standard, outbound, err := ParseProxyNode(frontSrc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("前置节点无法由 Xray 解析: %w", err)
+		}
+		if standard != "" {
+			hop, err := chainHopFromStandardProxy(standard)
+			if err != nil {
+				return nil, nil, err
+			}
+			frontOutbound = chainSocks5Outbound(hop, "front-hop", "")
+		} else {
+			frontOutbound = outbound
+			frontOutbound["tag"] = "front-hop"
+		}
+	}
+	landing := chainSocks5Outbound(cfg.Landing, "landing-hop", "front-hop")
+	routes := []interface{}{map[string]interface{}{"type": "field", "inboundTag": []string{"socks-in"}, "outboundTag": "landing-hop"}}
+	return []interface{}{frontOutbound, landing}, routes, nil
+}
+
+func buildSingBoxChainOutbounds(cfg *chainProxyConfig, proxies []config.BrowserProxy, currentProxyID string) ([]interface{}, string, error) {
+	front, err := resolveChainFront(cfg, proxies, currentProxyID)
+	if err != nil {
+		return nil, "", err
+	}
+	frontOutbound, err := BuildSingBoxOutbound(front.ProxyConfig)
+	if err != nil {
+		return nil, "", fmt.Errorf("前置节点无法由 sing-box 解析: %w", err)
+	}
+	frontOutbound["tag"] = "front-hop"
+	landing := map[string]interface{}{
+		"type": "socks", "tag": "landing-hop", "server": strings.TrimSpace(cfg.Landing.Server),
+		"server_port": cfg.Landing.Port, "detour": "front-hop",
+	}
+	if cfg.Landing.Protocol == "http" || cfg.Landing.Protocol == "https" {
+		landing["type"] = "http"
+	}
+	if strings.TrimSpace(cfg.Landing.Username) != "" {
+		landing["username"] = strings.TrimSpace(cfg.Landing.Username)
+		landing["password"] = cfg.Landing.Password
+	}
+	if cfg.Landing.Protocol == "https" || cfg.Landing.TLS {
+		landing["tls"] = map[string]interface{}{"enabled": true, "server_name": strings.TrimSpace(cfg.Landing.Server)}
+	}
+	return []interface{}{frontOutbound, landing}, "landing-hop", nil
+}
+
+func chainLandingURL(hop chainSocks5Hop) string {
+	scheme := normalizeChainHopProtocol(hop.Protocol)
+	host := strings.TrimSpace(hop.Server)
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		host = "[" + host + "]"
+	}
+	u := &url.URL{Scheme: scheme, Host: host + ":" + strconv.Itoa(hop.Port)}
+	if strings.TrimSpace(hop.Username) != "" {
+		u.User = url.UserPassword(strings.TrimSpace(hop.Username), hop.Password)
+	}
+	return u.String()
+}
+
+func buildMihomoChainNodes(cfg *chainProxyConfig, proxies []config.BrowserProxy, currentProxyID string) ([]interface{}, string, error) {
+	front, err := resolveChainFront(cfg, proxies, currentProxyID)
+	if err != nil {
+		return nil, "", err
+	}
+	frontNode, err := buildMihomoNode(front.ProxyConfig)
+	if err != nil {
+		return nil, "", fmt.Errorf("前置节点无法由 mihomo 解析: %w", err)
+	}
+	frontNode["name"] = "front-hop"
+	landingNode, err := proxyConfigToMapping(chainLandingURL(cfg.Landing))
+	if err != nil {
+		return nil, "", err
+	}
+	landingNode["name"] = "landing-hop"
+	landingNode["dialer-proxy"] = "front-hop"
+	return []interface{}{frontNode, landingNode}, "landing-hop", nil
+}

--- a/backend/internal/proxy/chain_proxy_test.go
+++ b/backend/internal/proxy/chain_proxy_test.go
@@ -1,0 +1,193 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"ant-chrome/backend/internal/config"
+)
+
+func buildGenericChainTestConfig(t *testing.T, frontID string, protocol string) string {
+	t.Helper()
+	payload := chainProxyConfig{
+		Version:      2,
+		FrontProxyID: frontID,
+		Landing:      chainSocks5Hop{Protocol: protocol, Server: "tr.example.com", Port: 1080, Username: "landing-user", Password: "landing-pass"},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return chainProxyPrefix + url.QueryEscape(string(data))
+}
+
+func TestGenericChainXrayUsesVLESSFrontToDialLanding(t *testing.T) {
+	chain := buildGenericChainTestConfig(t, "front-vless", "socks5")
+	proxies := []config.BrowserProxy{{
+		ProxyId:     "front-vless",
+		ProxyConfig: "vless://00000000-0000-0000-0000-000000000000@example.com:443?security=tls&sni=example.com&type=tcp",
+	}}
+	cfg, err := ParseChainProxyConfig(chain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outbounds, routes, err := buildXrayChainOutbounds(cfg, proxies, "chain-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outbounds) != 2 || len(routes) != 1 {
+		t.Fatalf("outbounds/routes = %d/%d", len(outbounds), len(routes))
+	}
+	front := outbounds[0].(map[string]interface{})
+	landing := outbounds[1].(map[string]interface{})
+	if front["protocol"] != "vless" || front["tag"] != "front-hop" {
+		t.Fatalf("front = %#v", front)
+	}
+	proxySettings, ok := landing["proxySettings"].(map[string]interface{})
+	if !ok || proxySettings["tag"] != "front-hop" {
+		t.Fatalf("landing proxySettings = %#v", landing["proxySettings"])
+	}
+	if routes[0].(map[string]interface{})["outboundTag"] != "landing-hop" {
+		t.Fatalf("route = %#v", routes[0])
+	}
+
+	resolution, err := ResolveProxyKernel(chain, proxies, "chain-id", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.Kernel != ProxyKernelXray {
+		t.Fatalf("kernel = %s, want xray", resolution.Kernel)
+	}
+}
+
+func TestGenericChainSingBoxDetoursLandingThroughHysteria2(t *testing.T) {
+	chain := buildGenericChainTestConfig(t, "front-hy2", "https")
+	proxies := []config.BrowserProxy{{ProxyId: "front-hy2", ProxyConfig: "hysteria2://password@hy.example.com:443?sni=hy.example.com"}}
+	cfg, err := ParseChainProxyConfig(chain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outbounds, routeTag, err := buildSingBoxChainOutbounds(cfg, proxies, "chain-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if routeTag != "landing-hop" || len(outbounds) != 2 {
+		t.Fatalf("route/outbounds = %s/%d", routeTag, len(outbounds))
+	}
+	landing := outbounds[1].(map[string]interface{})
+	if landing["type"] != "http" || landing["detour"] != "front-hop" {
+		t.Fatalf("landing = %#v", landing)
+	}
+	resolution, err := ResolveProxyKernel(chain, proxies, "chain-id", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.Kernel != ProxyKernelSingBox {
+		t.Fatalf("kernel = %s, want sing-box", resolution.Kernel)
+	}
+}
+
+func TestGenericChainRejectsMissingOrNestedFront(t *testing.T) {
+	chain := buildGenericChainTestConfig(t, "missing", "socks5")
+	if _, err := ResolveProxyKernel(chain, nil, "chain-id", ""); err == nil {
+		t.Fatal("expected missing front to fail")
+	}
+	nested := []config.BrowserProxy{{ProxyId: "missing", ProxyConfig: chain}}
+	if _, err := ResolveProxyKernel(chain, nested, "chain-id", ""); err == nil {
+		t.Fatal("expected nested front to fail")
+	}
+}
+
+func TestGenericChainMihomoUsesDialerProxy(t *testing.T) {
+	chain := buildGenericChainTestConfig(t, "front-vless", "socks5")
+	proxies := []config.BrowserProxy{{ProxyId: "front-vless", ProxyConfig: "name: vless-front\ntype: vless\nserver: example.com\nport: 443\nuuid: 00000000-0000-0000-0000-000000000000\ntls: true"}}
+	cfg, err := ParseChainProxyConfig(chain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodes, target, err := buildMihomoChainNodes(cfg, proxies, "chain-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "landing-hop" || len(nodes) != 2 {
+		t.Fatalf("target/nodes = %s/%d", target, len(nodes))
+	}
+	landing := nodes[1].(map[string]interface{})
+	if landing["dialer-proxy"] != "front-hop" {
+		t.Fatalf("landing = %#v", landing)
+	}
+}
+
+func TestGenericChainFallsBackFromStaleMihomoPreferenceToXray(t *testing.T) {
+	chain := buildGenericChainTestConfig(t, "front-vless", "socks5")
+	proxies := []config.BrowserProxy{{ProxyId: "front-vless", ProxyConfig: "vless://00000000-0000-0000-0000-000000000000@example.com:443"}}
+	resolution, err := ResolveProxyKernel(chain, proxies, "chain-id", ProxyKernelMihomo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.Kernel != ProxyKernelXray {
+		t.Fatalf("kernel = %s, want xray", resolution.Kernel)
+	}
+	if !strings.Contains(resolution.Reason, "回退") {
+		t.Fatalf("reason = %q", resolution.Reason)
+	}
+}
+
+func TestGenericChainFallsBackFromStaleSingBoxPreferenceToXray(t *testing.T) {
+	chain := buildGenericChainTestConfig(t, "front-vless", "socks5")
+	proxies := []config.BrowserProxy{{ProxyId: "front-vless", ProxyConfig: "vless://00000000-0000-0000-0000-000000000000@example.com:443"}}
+	resolution, err := ResolveProxyKernel(chain, proxies, "chain-id", ProxyKernelSingBox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.Kernel != ProxyKernelXray {
+		t.Fatalf("kernel = %s, want xray", resolution.Kernel)
+	}
+}
+
+func TestGenericChainStartsRealXrayBridgeWhenConfigured(t *testing.T) {
+	binary := strings.TrimSpace(os.Getenv("ANTIBROWSER_TEST_XRAY"))
+	if binary == "" {
+		t.Skip("ANTIBROWSER_TEST_XRAY is not set")
+	}
+	chain := buildGenericChainTestConfig(t, "front-vless", "socks5")
+	proxies := []config.BrowserProxy{{ProxyId: "front-vless", ProxyConfig: "vless://00000000-0000-0000-0000-000000000000@example.com:443?security=tls&sni=example.com&type=tcp"}}
+	cfg := config.DefaultConfig()
+	cfg.Browser.XrayBinaryPath = binary
+	cfg.Browser.UserDataRoot = t.TempDir()
+	manager := NewXrayManager(cfg, t.TempDir())
+	socksURL, key, err := manager.AcquireBridge(chain, proxies, "chain-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.ReleaseBridge(key)
+	defer manager.StopAll()
+	if !strings.HasPrefix(socksURL, "socks5://127.0.0.1:") {
+		t.Fatalf("socks URL = %s", socksURL)
+	}
+}
+
+func TestGenericChainStartsRealSingBoxBridgeWhenConfigured(t *testing.T) {
+	binary := strings.TrimSpace(os.Getenv("ANTIBROWSER_TEST_SINGBOX"))
+	if binary == "" {
+		t.Skip("ANTIBROWSER_TEST_SINGBOX is not set")
+	}
+	chain := buildGenericChainTestConfig(t, "front-hy2", "socks5")
+	proxies := []config.BrowserProxy{{ProxyId: "front-hy2", ProxyConfig: "hysteria2://password@hy.example.com:443?sni=hy.example.com"}}
+	cfg := config.DefaultConfig()
+	cfg.Browser.SingBoxBinaryPath = binary
+	cfg.Browser.UserDataRoot = t.TempDir()
+	manager := NewSingBoxManager(cfg, t.TempDir())
+	socksURL, key, err := manager.AcquireBridge(chain, proxies, "chain-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.ReleaseBridge(key)
+	defer manager.StopAll()
+	if !strings.HasPrefix(socksURL, "socks5://127.0.0.1:") {
+		t.Fatalf("socks URL = %s", socksURL)
+	}
+}

--- a/backend/internal/proxy/diagnostics.go
+++ b/backend/internal/proxy/diagnostics.go
@@ -91,10 +91,10 @@ func BuildProxyDiagnostic(proxyConfig string, proxies []config.BrowserProxy, pro
 	}
 	switch resolution.Kernel {
 	case ProxyKernelMihomo:
-		buildMihomoDiagnostic(src, options.ClashMgr, &result)
+		buildMihomoDiagnostic(src, proxies, proxyId, options.ClashMgr, &result)
 		return result
 	case ProxyKernelSingBox:
-		buildSingBoxDiagnostic(src, options.SingBoxMgr, &result)
+		buildSingBoxDiagnostic(src, proxies, proxyId, options.SingBoxMgr, &result)
 		return result
 	case ProxyKernelXray:
 		buildXrayDiagnostic(src, proxies, proxyId, options.XrayMgr, &result)
@@ -109,8 +109,28 @@ func BuildProxyDiagnostic(proxyConfig string, proxies []config.BrowserProxy, pro
 	return result
 }
 
-func buildMihomoDiagnostic(src string, manager *ClashManager, result *ProxyBuildDiagnostic) {
+func buildMihomoDiagnostic(src string, proxies []config.BrowserProxy, proxyId string, manager *ClashManager, result *ProxyBuildDiagnostic) {
 	result.Engine = "mihomo"
+	if IsChainProxy(src) {
+		cfg, err := ParseChainProxyConfig(src)
+		if err != nil {
+			result.Errors = append(result.Errors, err.Error())
+			return
+		}
+		nodes, _, err := buildMihomoChainNodes(cfg, proxies, proxyId)
+		if err != nil {
+			result.Errors = append(result.Errors, err.Error())
+			return
+		}
+		result.Ok = true
+		result.NodeKey = computeNodeKey(src + "\x00mihomo")
+		for _, node := range nodes {
+			if item, ok := node.(map[string]interface{}); ok {
+				result.Outbounds = append(result.Outbounds, sanitizeDiagnosticMap(item))
+			}
+		}
+		return
+	}
 	node, err := buildMihomoNode(src)
 	if err != nil {
 		result.Errors = append(result.Errors, err.Error())
@@ -126,8 +146,28 @@ func buildMihomoDiagnostic(src string, manager *ClashManager, result *ProxyBuild
 	}
 }
 
-func buildSingBoxDiagnostic(src string, manager *SingBoxManager, result *ProxyBuildDiagnostic) {
+func buildSingBoxDiagnostic(src string, proxies []config.BrowserProxy, proxyId string, manager *SingBoxManager, result *ProxyBuildDiagnostic) {
 	result.Engine = "sing-box"
+	if IsChainProxy(src) {
+		cfg, err := ParseChainProxyConfig(src)
+		if err != nil {
+			result.Errors = append(result.Errors, err.Error())
+			return
+		}
+		outbounds, _, err := buildSingBoxChainOutbounds(cfg, proxies, proxyId)
+		if err != nil {
+			result.Errors = append(result.Errors, err.Error())
+			return
+		}
+		result.Ok = true
+		result.NodeKey = computeNodeKey(src)
+		for _, outbound := range outbounds {
+			if item, ok := outbound.(map[string]interface{}); ok {
+				result.Outbounds = append(result.Outbounds, sanitizeDiagnosticMap(item))
+			}
+		}
+		return
+	}
 	outbound, err := BuildSingBoxOutbound(src)
 	if err != nil {
 		result.Errors = append(result.Errors, err.Error())
@@ -146,7 +186,24 @@ func buildSingBoxDiagnostic(src string, manager *SingBoxManager, result *ProxyBu
 func buildXrayDiagnostic(src string, proxies []config.BrowserProxy, proxyId string, manager *XrayManager, result *ProxyBuildDiagnostic) {
 	result.Engine = "xray"
 	var preferredKeySource string
-	if IsChainSocks5Proxy(src) {
+	if IsChainProxy(src) {
+		chainCfg, err := ParseChainProxyConfig(src)
+		if err != nil {
+			result.Errors = append(result.Errors, err.Error())
+			return
+		}
+		outbounds, routes, err := buildXrayChainOutbounds(chainCfg, proxies, proxyId)
+		if err != nil {
+			result.Errors = append(result.Errors, err.Error())
+			return
+		}
+		for _, outbound := range outbounds {
+			if item, ok := outbound.(map[string]interface{}); ok {
+				result.Outbounds = append(result.Outbounds, sanitizeDiagnosticMap(item))
+			}
+		}
+		result.Routes = routes
+	} else if IsChainSocks5Proxy(src) {
 		chainCfg, err := ParseChainSocks5Config(src)
 		if err != nil {
 			result.Errors = append(result.Errors, err.Error())

--- a/backend/internal/proxy/kernel_resolver.go
+++ b/backend/internal/proxy/kernel_resolver.go
@@ -72,6 +72,11 @@ func ResolveProxyKernel(proxyConfig string, proxies []config.BrowserProxy, proxy
 	}
 	if preferred != ProxyKernelAuto {
 		if !containsKernel(resolution.SupportedKernels, preferred) {
+			if protocol == "chain+proxy" {
+				resolution.Kernel = resolution.SupportedKernels[0]
+				resolution.Reason = fmt.Sprintf("链式代理指定内核 %s 不可用，已回退到 %s", preferred, resolution.Kernel)
+				return resolution, nil
+			}
 			return resolution, fmt.Errorf("协议 %s 不支持指定内核 %s", protocol, preferred)
 		}
 		resolution.Kernel = preferred
@@ -104,6 +109,9 @@ func DetectProxyProtocol(proxyConfig string) string {
 	if IsChainSocks5Proxy(src) {
 		return "chain+socks5"
 	}
+	if IsChainProxy(src) {
+		return "chain+proxy"
+	}
 	if nodeType := clashNodeType(src); nodeType != "" {
 		return nodeType
 	}
@@ -129,6 +137,33 @@ func SupportedKernelsForProtocol(protocol string, proxyConfig string, proxies []
 		return []string{ProxyKernelNative}
 	case "vmess", "vless", "trojan", "chain+socks5":
 		return []string{ProxyKernelXray, ProxyKernelMihomo}
+	case "chain+proxy":
+		cfg, err := ParseChainProxyConfig(proxyConfig)
+		if err != nil {
+			return nil
+		}
+		front, err := resolveChainFront(cfg, proxies, proxyId)
+		if err != nil {
+			return nil
+		}
+		switch DetectProxyProtocol(front.ProxyConfig) {
+		case "http", "socks5", "vmess", "vless", "trojan":
+			return []string{ProxyKernelXray}
+		case "ss", "shadowsocks":
+			return []string{ProxyKernelXray}
+		case "hysteria", "hysteria2", "tuic", "anytls":
+			return []string{ProxyKernelSingBox}
+		case "mieru", "wireguard":
+			return []string{ProxyKernelMihomo}
+		default:
+			if IsSingBoxProtocol(front.ProxyConfig) {
+				return []string{ProxyKernelSingBox}
+			}
+			if IsMihomoOnlyProtocol(front.ProxyConfig) {
+				return []string{ProxyKernelMihomo}
+			}
+		}
+		return nil
 	case "ss", "shadowsocks":
 		if IsMihomoOnlyProtocol(proxyConfig) {
 			return []string{ProxyKernelMihomo}

--- a/backend/internal/proxy/mihomo_bridge.go
+++ b/backend/internal/proxy/mihomo_bridge.go
@@ -94,19 +94,40 @@ func (m *ClashManager) ensureNodeBridge(proxyConfig string, proxies []config.Bro
 	if err != nil {
 		return "", "", err
 	}
-	node, err := buildMihomoNode(src)
-	if err != nil {
-		return "", "", err
+	var nodes []interface{}
+	targetName := ""
+	preferredPort := 0
+	if IsChainProxy(src) {
+		chainCfg, err := ParseChainProxyConfig(src)
+		if err != nil {
+			return "", "", err
+		}
+		nodes, targetName, err = buildMihomoChainNodes(chainCfg, proxies, proxyId)
+		if err != nil {
+			return "", "", err
+		}
+		preferredPort = chainCfg.LocalPort
+	} else {
+		node, err := buildMihomoNode(src)
+		if err != nil {
+			return "", "", err
+		}
+		nodes = []interface{}{node}
+		targetName = strings.TrimSpace(getMapString(node, "name"))
 	}
-	port, err := nextAvailablePort()
-	if err != nil {
-		return "", "", err
+	port := preferredPort
+	if port <= 0 {
+		var err error
+		port, err = nextAvailablePort()
+		if err != nil {
+			return "", "", err
+		}
 	}
 	controllerPort, err := nextAvailablePort()
 	if err != nil {
 		return "", "", err
 	}
-	cfgPath, err := m.buildMihomoNodeConfig(key, node, port, controllerPort)
+	cfgPath, err := m.buildMihomoNodesConfig(key, nodes, targetName, port, controllerPort)
 	if err != nil {
 		return "", "", err
 	}
@@ -315,14 +336,26 @@ func (m *ClashManager) lockLaunchForKey(key string) func() {
 }
 
 func (m *ClashManager) buildMihomoNodeConfig(key string, node map[string]interface{}, port int, controllerPort int) (string, error) {
+	return m.buildMihomoNodesConfig(key, []interface{}{node}, strings.TrimSpace(getMapString(node, "name")), port, controllerPort)
+}
+
+func (m *ClashManager) buildMihomoNodesConfig(key string, nodes []interface{}, targetName string, port int, controllerPort int) (string, error) {
 	baseDir := m.resolveMihomoWorkdir(key)
 	if err := os.MkdirAll(baseDir, 0o755); err != nil {
 		return "", err
 	}
-	name := strings.TrimSpace(getMapString(node, "name"))
+	if len(nodes) == 0 {
+		return "", fmt.Errorf("mihomo 节点配置为空")
+	}
+	name := strings.TrimSpace(targetName)
 	if name == "" {
-		name = "node"
-		node["name"] = name
+		if node, ok := nodes[0].(map[string]interface{}); ok {
+			name = strings.TrimSpace(getMapString(node, "name"))
+			if name == "" {
+				name = "node"
+				node["name"] = name
+			}
+		}
 	}
 	payload := map[string]interface{}{
 		"mixed-port":          port,
@@ -333,7 +366,7 @@ func (m *ClashManager) buildMihomoNodeConfig(key string, node map[string]interfa
 		"ipv6":                true,
 		"unified-delay":       true,
 		"tcp-concurrent":      false,
-		"proxies":             []interface{}{node},
+		"proxies":             nodes,
 		"proxy-groups": []interface{}{
 			map[string]interface{}{
 				"name":    "proxy-out",

--- a/backend/internal/proxy/singbox_bridge_recovery.go
+++ b/backend/internal/proxy/singbox_bridge_recovery.go
@@ -30,7 +30,10 @@ func (m *SingBoxManager) restartBridgeOnSamePort(log *logger.Logger, key string,
 		m.mu.Unlock()
 		return errSingBoxBridgeRestartNotNeeded
 	}
-	if len(bridge.Outbound) == 0 {
+	if len(bridge.Outbounds) == 0 && len(bridge.Outbound) > 0 {
+		bridge.Outbounds = []interface{}{cloneStringInterfaceMap(bridge.Outbound)}
+	}
+	if len(bridge.Outbounds) == 0 {
 		m.mu.Unlock()
 		return fmt.Errorf("sing-box 桥接缺少重启上下文")
 	}
@@ -45,7 +48,7 @@ func (m *SingBoxManager) restartBridgeOnSamePort(log *logger.Logger, key string,
 		logger.F("key", key[:8]),
 		logger.F("port", bridge.Port),
 	)
-	restarted, err := m.launchBridgeOnPort(log, key, binaryPath, cloneStringInterfaceMap(bridge.Outbound), bridge.Port, 1)
+	restarted, err := m.launchBridgeOnPort(log, key, binaryPath, cloneInterfaceSlice(bridge.Outbounds), bridge.RouteOutbound, bridge.Port, 1)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/proxy/singbox_bridge_runtime.go
+++ b/backend/internal/proxy/singbox_bridge_runtime.go
@@ -51,10 +51,26 @@ func (m *SingBoxManager) ensureBridge(proxyConfig string, proxies []config.Brows
 	}
 
 	src = normalizeNodeScheme(src)
-	outbound, err := BuildSingBoxOutbound(src)
-	if err != nil {
-		log.Error("节点解析失败", logger.F("error", err))
-		return "", "", err
+	var outbounds []interface{}
+	routeOutbound := "proxy-out"
+	preferredPort := 0
+	if IsChainProxy(src) {
+		chainCfg, err := ParseChainProxyConfig(src)
+		if err != nil {
+			return "", "", err
+		}
+		outbounds, routeOutbound, err = buildSingBoxChainOutbounds(chainCfg, proxies, proxyId)
+		if err != nil {
+			return "", "", err
+		}
+		preferredPort = chainCfg.LocalPort
+	} else {
+		outbound, err := BuildSingBoxOutbound(src)
+		if err != nil {
+			log.Error("节点解析失败", logger.F("error", err))
+			return "", "", err
+		}
+		outbounds = []interface{}{outbound}
 	}
 
 	key := computeNodeKey(src)
@@ -77,18 +93,25 @@ func (m *SingBoxManager) ensureBridge(proxyConfig string, proxies []config.Brows
 	}
 	log.Debug("sing-box binary", logger.F("path", binaryPath))
 
-	const maxRetries = 2
+	maxRetries := 2
+	if preferredPort > 0 {
+		maxRetries = 1
+	}
 	var lastErr error
 	attemptsUsed := 0
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		attemptsUsed = attempt
-		port, err := nextAvailablePort()
-		if err != nil {
-			lastErr = err
-			continue
+		port := preferredPort
+		if port <= 0 {
+			var err error
+			port, err = nextAvailablePort()
+			if err != nil {
+				lastErr = err
+				continue
+			}
 		}
 
-		bridge, err := m.launchBridgeOnPort(log, key, binaryPath, outbound, port, attempt)
+		bridge, err := m.launchBridgeOnPort(log, key, binaryPath, outbounds, routeOutbound, port, attempt)
 		if err != nil {
 			lastErr = err
 			if !isRetryableSingBoxLaunchError(err) {
@@ -111,8 +134,8 @@ func (m *SingBoxManager) ensureBridge(proxyConfig string, proxies []config.Brows
 	return "", "", fmt.Errorf("sing-box 启动失败（已尝试 %d 次）: %w", attemptsUsed, lastErr)
 }
 
-func (m *SingBoxManager) launchBridgeOnPort(log *logger.Logger, key string, binaryPath string, outbound map[string]interface{}, port int, attempt int) (*SingBoxBridge, error) {
-	cfgPath, err := m.buildConfig(key, outbound, port)
+func (m *SingBoxManager) launchBridgeOnPort(log *logger.Logger, key string, binaryPath string, outbounds []interface{}, routeOutbound string, port int, attempt int) (*SingBoxBridge, error) {
+	cfgPath, err := m.buildConfig(key, outbounds, routeOutbound, port)
 	if err != nil {
 		return nil, fmt.Errorf("sing-box 配置生成失败: %w", err)
 	}
@@ -139,13 +162,19 @@ func (m *SingBoxManager) launchBridgeOnPort(log *logger.Logger, key string, bina
 	}
 
 	bridge := &SingBoxBridge{
-		NodeKey:    key,
-		Port:       port,
-		Cmd:        cmd,
-		Pid:        cmd.Process.Pid,
-		Running:    true,
-		Outbound:   cloneStringInterfaceMap(outbound),
-		LastUsedAt: time.Now(),
+		NodeKey:       key,
+		Port:          port,
+		Cmd:           cmd,
+		Pid:           cmd.Process.Pid,
+		Running:       true,
+		Outbounds:     cloneInterfaceSlice(outbounds),
+		RouteOutbound: routeOutbound,
+		LastUsedAt:    time.Now(),
+	}
+	if len(outbounds) == 1 {
+		if outbound, ok := outbounds[0].(map[string]interface{}); ok {
+			bridge.Outbound = cloneStringInterfaceMap(outbound)
+		}
 	}
 	bridge.startExitWatcher()
 	log.Info("sing-box 内核进程已启动", logger.F("engine", "sing-box"), logger.F("key", key[:8]), logger.F("pid", bridge.Pid), logger.F("port", port))

--- a/backend/internal/proxy/singbox_runtime_helpers.go
+++ b/backend/internal/proxy/singbox_runtime_helpers.go
@@ -79,12 +79,17 @@ func (m *SingBoxManager) resolveBinary() (string, error) {
 	return "", fmt.Errorf("未找到 sing-box 可执行文件。请将 sing-box 放到 bin/%s/ 或 bin/ 目录，或在配置中设置 SingBoxBinaryPath", platformDir)
 }
 
-func (m *SingBoxManager) buildConfig(key string, outbound map[string]interface{}, port int) (string, error) {
+func (m *SingBoxManager) buildConfig(key string, outbounds []interface{}, routeOutbound string, port int) (string, error) {
 	baseDir := m.resolveWorkdir(key)
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return "", err
 	}
 
+	if strings.TrimSpace(routeOutbound) == "" {
+		routeOutbound = "proxy-out"
+	}
+	runtimeOutbounds := cloneInterfaceSlice(outbounds)
+	runtimeOutbounds = append(runtimeOutbounds, map[string]interface{}{"type": "direct", "tag": "direct"})
 	cfg := map[string]interface{}{
 		"log": map[string]interface{}{
 			"level":     "warn",
@@ -100,13 +105,7 @@ func (m *SingBoxManager) buildConfig(key string, outbound map[string]interface{}
 				"listen_port": port,
 			},
 		},
-		"outbounds": []interface{}{
-			outbound,
-			map[string]interface{}{
-				"type": "direct",
-				"tag":  "direct",
-			},
-		},
+		"outbounds": runtimeOutbounds,
 		"route": map[string]interface{}{
 			"default_domain_resolver": "public-dns",
 			"rules": []interface{}{
@@ -116,7 +115,7 @@ func (m *SingBoxManager) buildConfig(key string, outbound map[string]interface{}
 				},
 				map[string]interface{}{
 					"inbound":  []string{"socks-in"},
-					"outbound": "proxy-out",
+					"outbound": routeOutbound,
 				},
 			},
 		},

--- a/backend/internal/proxy/singbox_types.go
+++ b/backend/internal/proxy/singbox_types.go
@@ -14,22 +14,24 @@ const (
 
 // SingBoxBridge sing-box 桥接进程
 type SingBoxBridge struct {
-	NodeKey      string
-	Port         int
-	Cmd          *exec.Cmd
-	Pid          int
-	Running      bool
-	Stopping     bool
-	LastError    string
-	Outbound     map[string]interface{}
-	RefCount     int
-	LastUsedAt   time.Time
-	Restarting   bool
-	RestartCount int
-	ExitDone     chan struct{}
-	ExitErr      error
-	exitMu       sync.Mutex
-	waitOnce     sync.Once
+	NodeKey       string
+	Port          int
+	Cmd           *exec.Cmd
+	Pid           int
+	Running       bool
+	Stopping      bool
+	LastError     string
+	Outbounds     []interface{}
+	RouteOutbound string
+	Outbound      map[string]interface{}
+	RefCount      int
+	LastUsedAt    time.Time
+	Restarting    bool
+	RestartCount  int
+	ExitDone      chan struct{}
+	ExitErr       error
+	exitMu        sync.Mutex
+	waitOnce      sync.Once
 }
 
 // SingBoxManager sing-box 桥接管理器

--- a/backend/internal/proxy/xray.go
+++ b/backend/internal/proxy/xray.go
@@ -80,6 +80,16 @@ func ValidateProxyConfig(proxyConfig string, proxies []config.BrowserProxy, prox
 		}
 		return true, ""
 	}
+	if IsChainProxy(src) {
+		cfg, err := ParseChainProxyConfig(src)
+		if err != nil {
+			return false, fmt.Sprintf("链式代理配置解析失败: %v", err)
+		}
+		if _, err := resolveChainFront(cfg, proxies, proxyId); err != nil {
+			return false, err.Error()
+		}
+		return true, ""
+	}
 	if IsSingBoxProtocol(src) {
 		if _, err := BuildSingBoxOutbound(src); err != nil {
 			return false, fmt.Sprintf("代理配置解析失败: %v", err)
@@ -116,6 +126,9 @@ func RequiresBridge(proxyConfig string, proxies []config.BrowserProxy, proxyId s
 		return false
 	}
 	if IsChainSocks5Proxy(src) {
+		return true
+	}
+	if IsChainProxy(src) {
 		return true
 	}
 	if IsSingBoxProtocol(src) {

--- a/backend/internal/proxy/xray_bridge_launch.go
+++ b/backend/internal/proxy/xray_bridge_launch.go
@@ -35,7 +35,18 @@ func (m *XrayManager) ensureBridge(proxyConfig string, proxies []config.BrowserP
 		preferredPort int
 	)
 
-	if IsChainSocks5Proxy(src) {
+	if IsChainProxy(src) {
+		chainCfg, err := ParseChainProxyConfig(src)
+		if err != nil {
+			log.Error("通用链式节点解析失败", logger.F("error", err))
+			return "", "", err
+		}
+		outbounds, routes, err = buildXrayChainOutbounds(chainCfg, proxies, proxyId)
+		if err != nil {
+			return "", "", err
+		}
+		preferredPort = chainCfg.LocalPort
+	} else if IsChainSocks5Proxy(src) {
 		chainCfg, err := ParseChainSocks5Config(src)
 		if err != nil {
 			log.Error("链式节点解析失败", logger.F("error", err))

--- a/frontend/src/modules/browser/components/ProxyImportModal.helpers.ts
+++ b/frontend/src/modules/browser/components/ProxyImportModal.helpers.ts
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml'
 import type { BrowserProxy } from '../types'
-import { CHAIN_SOCKS5_PREFIX, type ChainImportForm, type ChainHopForm, type ChainSocks5Config, type ChainSocks5HopConfig, type ClashProxy, type DirectImportForm, type ImportCandidate, type ProxyDisplayInfo } from './ProxyImportModal.types'
+import { CHAIN_PROXY_PREFIX, CHAIN_SOCKS5_PREFIX, type ChainImportForm, type ChainHopForm, type ChainProxyConfig, type ChainSocks5Config, type ChainSocks5HopConfig, type ClashProxy, type DirectImportForm, type ImportCandidate, type ProxyDisplayInfo } from './ProxyImportModal.types'
 
 function parseChainSocks5Config(proxyConfig: string): ChainSocks5Config | null {
   const cfg = proxyConfig.trim()
@@ -16,7 +16,7 @@ function parseChainSocks5Config(proxyConfig: string): ChainSocks5Config | null {
     if (!raw || typeof raw !== 'object') return null
     const hop = raw as Record<string, unknown>
     const protocol = String(hop.protocol || '').trim().toLowerCase()
-    if (protocol && protocol !== 'socks5' && protocol !== 'http') return null
+    if (protocol && protocol !== 'socks5' && protocol !== 'http' && protocol !== 'https') return null
 
     const server = String(hop.server || '').trim()
     if (!server) return null
@@ -29,7 +29,7 @@ function parseChainSocks5Config(proxyConfig: string): ChainSocks5Config | null {
     if (password && !username) return null
 
     return {
-      protocol: protocol === 'http' ? 'http' : 'socks5',
+      protocol: protocol === 'http' || protocol === 'https' ? protocol : 'socks5',
       server,
       port: portVal,
       username: username || undefined,
@@ -67,6 +67,15 @@ export function parseProxyInfo(proxyConfig: string): { type: string; server: str
   const chain = parseChainSocks5Config(cfg)
   if (chain) {
     return { type: 'chain-socks5', server: '127.0.0.1', port: chain.localPort || 0 }
+  }
+
+  if (cfg.toLowerCase().startsWith(CHAIN_PROXY_PREFIX)) {
+    try {
+      const parsed = JSON.parse(decodeURIComponent(cfg.slice(CHAIN_PROXY_PREFIX.length))) as ChainProxyConfig
+      return { type: 'chain-proxy', server: parsed.landing?.server || '-', port: Number(parsed.localPort || 0) }
+    } catch {
+      return { type: 'chain-proxy', server: '-', port: 0 }
+    }
   }
 
   const urlMatch = cfg.match(/^([a-zA-Z0-9+\-]+):\/\//)
@@ -271,7 +280,7 @@ export function buildDirectImportCandidate(form: DirectImportForm): ImportCandid
 
 export function buildChainImportCandidate(form: ChainImportForm): ImportCandidate {
   const parseHop = (label: string, hop: ChainHopForm): ChainSocks5HopConfig => {
-    const protocol = hop.protocol === 'socks5' ? 'socks5' : 'http'
+    const protocol = hop.protocol
     const server = hop.server.trim()
     if (!server) {
       throw new Error(`请输入${label}代理地址`)
@@ -317,17 +326,22 @@ export function buildChainImportCandidate(form: ChainImportForm): ImportCandidat
     throw new Error('本地监听端口必须在 1-65535 之间')
   }
 
-  const payload: ChainSocks5Config = {
-    first: parseHop('第一层', form.first),
-    second: parseHop('第二层', form.second),
+  const frontProxyId = form.frontProxyId.trim()
+  if (!frontProxyId) {
+    throw new Error('请选择前置代理节点')
+  }
+  const payload: ChainProxyConfig = {
+    version: 2,
+    frontProxyId,
+    landing: parseHop('落地', form.landing),
     localPort: localPort > 0 ? localPort : undefined,
   }
 
   const encodedPayload = encodeURIComponent(JSON.stringify(payload))
-  const proxyConfig = `${CHAIN_SOCKS5_PREFIX}${encodedPayload}`
+  const proxyConfig = `${CHAIN_PROXY_PREFIX}${encodedPayload}`
 
   return {
-    proxyName: form.proxyName.trim() || `链式代理-${payload.first.server}-${payload.second.server}`,
+    proxyName: form.proxyName.trim() || `链式代理-${payload.landing.server}`,
     proxyConfig,
   }
 }

--- a/frontend/src/modules/browser/components/ProxyImportModal.tsx
+++ b/frontend/src/modules/browser/components/ProxyImportModal.tsx
@@ -82,11 +82,11 @@ export function ProxyImportModal({
     }
   }
 
-  const updateChainHop = (hop: 'first' | 'second', field: keyof ChainHopForm, value: string) => {
+  const updateChainLanding = (field: keyof ChainHopForm, value: string) => {
     setChainImportForm(prev => ({
       ...prev,
-      [hop]: {
-        ...prev[hop],
+      landing: {
+        ...prev.landing,
         [field]: value,
       },
     }))
@@ -251,10 +251,9 @@ export function ProxyImportModal({
     ? !!importText.trim()
     : importMode === 'direct'
       ? !!directImportText.trim() || (!!directImportForm.server.trim() && !!directImportForm.port.trim())
-      : !!chainImportForm.first.server.trim()
-        && !!chainImportForm.first.port.trim()
-        && !!chainImportForm.second.server.trim()
-        && !!chainImportForm.second.port.trim()
+      : !!chainImportForm.frontProxyId.trim()
+        && !!chainImportForm.landing.server.trim()
+        && !!chainImportForm.landing.port.trim()
 
   const previewColumns = useMemo<TableColumn<ProxyDisplayInfo>[]>(() => [
     { key: 'proxyName', title: '代理名称', width: '200px' },
@@ -295,7 +294,10 @@ export function ProxyImportModal({
       directImportForm={directImportForm}
       chainImportForm={chainImportForm}
       groups={groups}
-      fetchProxyOptions={existingProxies.filter(proxy => proxy.proxyConfig.trim() && !proxy.proxyConfig.trim().toLowerCase().startsWith('direct://'))}
+      fetchProxyOptions={existingProxies.filter(proxy => {
+        const config = proxy.proxyConfig.trim().toLowerCase()
+        return !!config && !config.startsWith('direct://') && !config.startsWith('chain+proxy://') && !config.startsWith('chain+socks5://')
+      })}
       previewModalOpen={previewModalOpen}
       previewList={previewList}
       importing={importing}
@@ -313,7 +315,7 @@ export function ProxyImportModal({
       onDirectImportTextChange={setDirectImportText}
       onDirectImportFormChange={setDirectImportForm}
       onChainImportFormChange={setChainImportForm}
-      onUpdateChainHop={updateChainHop}
+      onUpdateChainLanding={updateChainLanding}
       onFillDirectTemplate={handleFillDirectTemplate}
       onCopyDirectTemplate={handleCopyDirectTemplate}
       onApplyDirectText={handleApplyDirectText}

--- a/frontend/src/modules/browser/components/ProxyImportModal.types.ts
+++ b/frontend/src/modules/browser/components/ProxyImportModal.types.ts
@@ -30,7 +30,7 @@ export interface DirectImportForm {
 }
 
 export interface ChainHopForm {
-  protocol: 'http' | 'socks5'
+  protocol: 'http' | 'https' | 'socks5'
   server: string
   port: string
   username: string
@@ -40,8 +40,8 @@ export interface ChainHopForm {
 export interface ChainImportForm {
   proxyName: string
   localPort: string
-  first: ChainHopForm
-  second: ChainHopForm
+  frontProxyId: string
+  landing: ChainHopForm
 }
 
 export const DIRECT_PROXY_PROTOCOL_OPTIONS = [
@@ -62,14 +62,8 @@ export const INITIAL_DIRECT_IMPORT_FORM: DirectImportForm = {
 export const INITIAL_CHAIN_IMPORT_FORM: ChainImportForm = {
   proxyName: '',
   localPort: '',
-  first: {
-    protocol: 'http',
-    server: '',
-    port: '',
-    username: '',
-    password: '',
-  },
-  second: {
+  frontProxyId: '',
+  landing: {
     protocol: 'http',
     server: '',
     port: '',
@@ -95,9 +89,10 @@ export interface ProxyDisplayInfo {
 }
 
 export const CHAIN_SOCKS5_PREFIX = 'chain+socks5://'
+export const CHAIN_PROXY_PREFIX = 'chain+proxy://'
 
 export interface ChainSocks5HopConfig {
-  protocol: 'http' | 'socks5'
+  protocol: 'http' | 'https' | 'socks5'
   server: string
   port: number
   username?: string
@@ -108,4 +103,11 @@ export interface ChainSocks5Config {
   localPort?: number
   first: ChainSocks5HopConfig
   second: ChainSocks5HopConfig
+}
+
+export interface ChainProxyConfig {
+  version: 2
+  frontProxyId: string
+  landing: ChainSocks5HopConfig
+  localPort?: number
 }

--- a/frontend/src/modules/browser/components/ProxyImportModalView.tsx
+++ b/frontend/src/modules/browser/components/ProxyImportModalView.tsx
@@ -46,7 +46,7 @@ interface ProxyImportModalViewProps {
   onDirectImportTextChange: (value: string) => void
   onDirectImportFormChange: import("react").Dispatch<import("react").SetStateAction<DirectImportForm>>
   onChainImportFormChange: import("react").Dispatch<import("react").SetStateAction<ChainImportForm>>
-  onUpdateChainHop: (hop: 'first' | 'second', field: keyof ChainHopForm, value: string) => void
+  onUpdateChainLanding: (field: keyof ChainHopForm, value: string) => void
   onFillDirectTemplate: () => void
   onCopyDirectTemplate: () => Promise<void>
   onApplyDirectText: () => void
@@ -89,7 +89,7 @@ export function ProxyImportModalView({
   onDirectImportTextChange,
   onDirectImportFormChange,
   onChainImportFormChange,
-  onUpdateChainHop,
+  onUpdateChainLanding,
   onFillDirectTemplate,
   onCopyDirectTemplate,
   onApplyDirectText,
@@ -278,72 +278,36 @@ export function ProxyImportModalView({
                 </FormItem>
               </div>
 
-              <div className="rounded-md border border-[var(--color-border)] p-3 space-y-3">
-                <h4 className="text-sm font-medium text-[var(--color-text-primary)]">第一层代理</h4>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <FormItem label="协议">
-                    <Select
-                      value={chainImportForm.first.protocol}
-                      onChange={e => onUpdateChainHop('first', 'protocol', e.target.value)}
-                      options={[
-                        { value: 'http', label: 'HTTP' },
-                        { value: 'socks5', label: 'SOCKS5' },
-                      ]}
-                    />
-                  </FormItem>
-                  <FormItem label="代理地址" required>
-                    <Input
-                      value={chainImportForm.first.server}
-                      onChange={e => onUpdateChainHop('first', 'server', e.target.value)}
-                      placeholder="例如：s1.example.com"
-                    />
-                  </FormItem>
-                  <FormItem label="代理端口" required>
-                    <Input
-                      type="number"
-                      min={1}
-                      max={65535}
-                      value={chainImportForm.first.port}
-                      onChange={e => onUpdateChainHop('first', 'port', e.target.value)}
-                      placeholder="例如：1080"
-                    />
-                  </FormItem>
-                  <FormItem label="账号（可选）">
-                    <Input
-                      value={chainImportForm.first.username}
-                      onChange={e => onUpdateChainHop('first', 'username', e.target.value)}
-                      placeholder="留空则不使用认证"
-                    />
-                  </FormItem>
-                  <FormItem label="密码（可选）">
-                    <Input
-                      type="password"
-                      value={chainImportForm.first.password}
-                      onChange={e => onUpdateChainHop('first', 'password', e.target.value)}
-                      placeholder="留空则不使用密码"
-                    />
-                  </FormItem>
-                </div>
-              </div>
+              <FormItem label="前置代理节点" required hint="可选择代理池中当前已导入、且现有内核支持的 VLESS / VMess / Trojan / SS / Hysteria2 / TUIC 等节点">
+                <Select
+                  value={chainImportForm.frontProxyId}
+                  onChange={e => onChainImportFormChange(prev => ({ ...prev, frontProxyId: e.target.value }))}
+                  options={[
+                    { value: '', label: '请选择前置节点' },
+                    ...fetchProxyOptions.map(proxy => ({ value: proxy.proxyId, label: proxy.proxyName || proxy.proxyId })),
+                  ]}
+                />
+              </FormItem>
 
               <div className="rounded-md border border-[var(--color-border)] p-3 space-y-3">
-                <h4 className="text-sm font-medium text-[var(--color-text-primary)]">第二层代理</h4>
+                <h4 className="text-sm font-medium text-[var(--color-text-primary)]">落地代理</h4>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <FormItem label="协议">
                     <Select
-                      value={chainImportForm.second.protocol}
-                      onChange={e => onUpdateChainHop('second', 'protocol', e.target.value)}
+                      value={chainImportForm.landing.protocol}
+                      onChange={e => onUpdateChainLanding('protocol', e.target.value)}
                       options={[
                         { value: 'http', label: 'HTTP' },
+                        { value: 'https', label: 'HTTPS' },
                         { value: 'socks5', label: 'SOCKS5' },
                       ]}
                     />
                   </FormItem>
                   <FormItem label="代理地址" required>
                     <Input
-                      value={chainImportForm.second.server}
-                      onChange={e => onUpdateChainHop('second', 'server', e.target.value)}
-                      placeholder="例如：s2.example.com"
+                      value={chainImportForm.landing.server}
+                      onChange={e => onUpdateChainLanding('server', e.target.value)}
+                      placeholder="例如：tr.example.com"
                     />
                   </FormItem>
                   <FormItem label="代理端口" required>
@@ -351,23 +315,23 @@ export function ProxyImportModalView({
                       type="number"
                       min={1}
                       max={65535}
-                      value={chainImportForm.second.port}
-                      onChange={e => onUpdateChainHop('second', 'port', e.target.value)}
+                      value={chainImportForm.landing.port}
+                      onChange={e => onUpdateChainLanding('port', e.target.value)}
                       placeholder="例如：1081"
                     />
                   </FormItem>
                   <FormItem label="账号（可选）">
                     <Input
-                      value={chainImportForm.second.username}
-                      onChange={e => onUpdateChainHop('second', 'username', e.target.value)}
+                      value={chainImportForm.landing.username}
+                      onChange={e => onUpdateChainLanding('username', e.target.value)}
                       placeholder="留空则不使用认证"
                     />
                   </FormItem>
                   <FormItem label="密码（可选）">
                     <Input
                       type="password"
-                      value={chainImportForm.second.password}
-                      onChange={e => onUpdateChainHop('second', 'password', e.target.value)}
+                      value={chainImportForm.landing.password}
+                      onChange={e => onUpdateChainLanding('password', e.target.value)}
                       placeholder="留空则不使用密码"
                     />
                   </FormItem>

--- a/frontend/src/modules/browser/components/ProxyPickerModal.edit.tsx
+++ b/frontend/src/modules/browser/components/ProxyPickerModal.edit.tsx
@@ -92,7 +92,7 @@ export function ProxyEditModal({
               value={editConfig}
               onChange={e => setEditConfig(e.target.value)}
               rows={6}
-              placeholder="支持 http://、https://、socks5://、chain+socks5://"
+              placeholder="支持 http://、https://、socks5://、chain+proxy://、chain+socks5://"
             />
           </FormItem>
         )}

--- a/frontend/src/modules/browser/pages/ProxyPoolPage.tsx
+++ b/frontend/src/modules/browser/pages/ProxyPoolPage.tsx
@@ -9,6 +9,7 @@ import {
   createInitialChainImportForm,
   INITIAL_DIRECT_IMPORT_FORM,
   ensureBuiltinProxies,
+  parseProxyInfo,
   toChainImportForm,
   toDirectImportForm,
   toDisplayList,
@@ -16,6 +17,7 @@ import {
   type DirectImportForm,
   type ProxyDisplayInfo,
 } from './proxyPool/helpers'
+
 import {
   ProxyPoolEditModal,
   ProxyPoolIPHealthDetailModal,
@@ -37,6 +39,21 @@ import { useProxyGlobalRefreshConfig } from './proxyPool/useProxyGlobalRefreshCo
 import { useProxyDeleteFlow } from './proxyPool/useProxyDeleteFlow'
 import { useProxyCoreDownload } from './proxyPool/useProxyCoreDownload'
 import { useProxyPoolFilter } from './proxyPool/useProxyPoolFilter'
+
+type KernelOption = { value: string; label: string }
+
+function resolveChainKernelOptions(form: ChainImportForm, proxies: BrowserProxy[]): KernelOption[] {
+  const front = proxies.find(proxy => proxy.proxyId === form.frontProxyId)
+  const protocol = front ? parseProxyInfo(front.proxyConfig).type.toLowerCase() : ''
+  const automatic: KernelOption = { value: 'auto', label: '自动（推荐）' }
+  if (['hysteria', 'hysteria2', 'tuic', 'anytls'].includes(protocol)) {
+    return [automatic, { value: 'sing-box', label: 'sing-box' }]
+  }
+  if (['mieru', 'wireguard'].includes(protocol)) {
+    return [automatic, { value: 'mihomo', label: 'Mihomo' }]
+  }
+  return [automatic, { value: 'xray', label: 'Xray' }]
+}
 
 export function ProxyPoolPage() {
   const [proxies, setProxies] = useState<BrowserProxy[]>([])
@@ -119,7 +136,7 @@ export function ProxyPoolPage() {
     chainImportForm, directImportForm, previewModalOpen, setPreviewModalOpen, previewList, removedPreviewProxyNames,
     importing, fetchingImportUrl, canParseImport, setImportText, setImportDnsServers,
     setImportNamePrefix, setImportGroupName, setImportFetchProxyId, setChainImportText, setDirectImportText,
-    setChainImportForm, setDirectImportForm, handleRemovePreviewProxy, updateChainImportHop,
+    setChainImportForm, setDirectImportForm, handleRemovePreviewProxy, updateChainImportLanding,
     handleImportModeChange, handleFillChainTemplate, handleFillDirectTemplate, handleCopyChainTemplate,
     handleCopyDirectTemplate, handleApplyChainJSON, handleApplyDirectText, handleImportUrlChange,
     handleFetchImportURL, handleParseImport, handleConfirmImport,
@@ -239,11 +256,11 @@ export function ProxyPoolPage() {
     removeSelectedId,
   } = useProxySelection({ proxies, filteredList, saveProxies })
 
-  const updateChainEditHop = (hop: 'first' | 'second', field: keyof ChainImportForm['first'], value: string) => {
+  const updateChainEditLanding = (field: keyof ChainImportForm['landing'], value: string) => {
     setChainEditForm(prev => ({
       ...prev,
-      [hop]: {
-        ...prev[hop],
+      landing: {
+        ...prev.landing,
         [field]: value,
       },
     }))
@@ -253,14 +270,18 @@ export function ProxyPoolPage() {
     const proxy = proxies.find(p => p.proxyId === record.proxyId)
     if (proxy) {
       setEditingProxy(proxy)
+      const nextChainForm = toChainImportForm(proxy.proxyName, proxy.proxyConfig)
+      const allowedKernels = nextChainForm
+        ? resolveChainKernelOptions(nextChainForm, proxies).map(option => option.value)
+        : []
+      const preferredKernel = proxy.preferredKernel || 'auto'
       setEditForm({
         proxyName: proxy.proxyName,
         proxyConfig: proxy.proxyConfig,
-        preferredKernel: proxy.preferredKernel || 'auto',
+        preferredKernel: nextChainForm && !allowedKernels.includes(preferredKernel) ? 'auto' : preferredKernel,
         dnsServers: proxy.dnsServers || '',
         groupName: proxy.groupName || '',
       })
-      const nextChainForm = toChainImportForm(proxy.proxyName, proxy.proxyConfig)
       const nextDirectForm = nextChainForm ? null : toDirectImportForm(proxy.proxyName, proxy.proxyConfig)
       if (nextChainForm) {
         setChainEditMode(true)
@@ -429,7 +450,10 @@ export function ProxyPoolPage() {
         chainImportForm={chainImportForm}
         directImportForm={directImportForm}
         fetchingImportUrl={fetchingImportUrl}
-        fetchProxyOptions={proxies.filter(proxy => proxy.proxyConfig.trim() && !proxy.proxyConfig.trim().toLowerCase().startsWith('direct://'))}
+        fetchProxyOptions={proxies.filter(proxy => {
+          const config = proxy.proxyConfig.trim().toLowerCase()
+          return !!config && !config.startsWith('direct://') && !config.startsWith('chain+proxy://') && !config.startsWith('chain+socks5://')
+        })}
         canParseImport={canParseImport}
         onClose={() => setImportModalOpen(false)}
         onParse={handleParseImport}
@@ -446,7 +470,7 @@ export function ProxyPoolPage() {
         onApplyChainJSON={handleApplyChainJSON}
         onApplyDirectText={handleApplyDirectText}
         onChainImportFormChange={(patch) => setChainImportForm((prev) => ({ ...prev, ...patch }))}
-        onChainImportHopChange={updateChainImportHop}
+        onChainImportLandingChange={updateChainImportLanding}
         onFillChainTemplate={handleFillChainTemplate}
         onCopyChainTemplate={() => void handleCopyChainTemplate()}
         onFillDirectTemplate={handleFillDirectTemplate}
@@ -477,6 +501,8 @@ export function ProxyPoolPage() {
         editForm={editForm}
         chainEditMode={chainEditMode}
         chainEditForm={chainEditForm}
+        chainKernelOptions={resolveChainKernelOptions(chainEditForm, proxies)}
+        frontProxyOptions={proxies.filter(proxy => proxy.proxyId !== editingProxy?.proxyId && !proxy.proxyConfig.trim().toLowerCase().startsWith('direct://') && !proxy.proxyConfig.trim().toLowerCase().startsWith('chain+'))}
         directEditMode={directEditMode}
         directEditForm={directEditForm}
         onClose={() => setEditModalOpen(false)}
@@ -484,7 +510,7 @@ export function ProxyPoolPage() {
         onChange={(patch) => setEditForm((prev) => ({ ...prev, ...patch }))}
         onChainEditFormChange={(patch) => setChainEditForm((prev) => ({ ...prev, ...patch }))}
         onDirectEditFormChange={(patch) => setDirectEditForm((prev) => ({ ...prev, ...patch }))}
-        onChainEditHopChange={updateChainEditHop}
+        onChainEditLandingChange={updateChainEditLanding}
       />
 
       <ProxyPoolIPHealthDetailModal

--- a/frontend/src/modules/browser/pages/proxyPool/ProxyPoolImportModal.tsx
+++ b/frontend/src/modules/browser/pages/proxyPool/ProxyPoolImportModal.tsx
@@ -42,7 +42,7 @@ interface ProxyPoolImportModalProps {
   onApplyChainJSON: () => void
   onApplyDirectText: () => void
   onChainImportFormChange: (patch: Partial<ChainImportForm>) => void
-  onChainImportHopChange: (hop: 'first' | 'second', field: keyof ChainImportForm['first'], value: string) => void
+  onChainImportLandingChange: (field: keyof ChainImportForm['landing'], value: string) => void
   onFillChainTemplate: () => void
   onCopyChainTemplate: () => void
   onFillDirectTemplate: () => void
@@ -89,7 +89,7 @@ export function ProxyPoolImportModal({
   onApplyChainJSON,
   onApplyDirectText,
   onChainImportFormChange,
-  onChainImportHopChange,
+  onChainImportLandingChange,
   onFillChainTemplate,
   onCopyChainTemplate,
   onFillDirectTemplate,
@@ -276,23 +276,34 @@ export function ProxyPoolImportModal({
                 />
               </FormItem>
             </div>
+            <FormItem label="前置代理节点" required hint="直接选择代理池里已导入并由现有内核支持的节点">
+              <Select
+                value={chainImportForm.frontProxyId}
+                onChange={(event) => onChainImportFormChange({ frontProxyId: event.target.value })}
+                options={[
+                  { value: '', label: '请选择 VLESS / VMess / Trojan / SS / Hysteria2 等前置节点' },
+                  ...fetchProxyOptions.map(proxy => ({ value: proxy.proxyId, label: proxy.proxyName || proxy.proxyId })),
+                ]}
+              />
+            </FormItem>
             <div className="rounded-md border border-[var(--color-border)] p-3 space-y-3">
-              <h4 className="text-sm font-medium text-[var(--color-text-primary)]">第一层代理</h4>
+              <h4 className="text-sm font-medium text-[var(--color-text-primary)]">落地代理</h4>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <FormItem label="协议">
                   <Select
-                    value={chainImportForm.first.protocol}
-                    onChange={(event) => onChainImportHopChange('first', 'protocol', event.target.value)}
+                    value={chainImportForm.landing.protocol}
+                    onChange={(event) => onChainImportLandingChange('protocol', event.target.value)}
                     options={[
                       { value: 'http', label: 'HTTP' },
+                      { value: 'https', label: 'HTTPS' },
                       { value: 'socks5', label: 'SOCKS5' },
                     ]}
                   />
                 </FormItem>
                 <FormItem label="代理地址" required>
                   <Input
-                    value={chainImportForm.first.server}
-                    onChange={(event) => onChainImportHopChange('first', 'server', event.target.value)}
+                    value={chainImportForm.landing.server}
+                    onChange={(event) => onChainImportLandingChange('server', event.target.value)}
                     placeholder="代理地址"
                   />
                 </FormItem>
@@ -301,67 +312,22 @@ export function ProxyPoolImportModal({
                     type="number"
                     min={1}
                     max={65535}
-                    value={chainImportForm.first.port}
-                    onChange={(event) => onChainImportHopChange('first', 'port', event.target.value)}
+                    value={chainImportForm.landing.port}
+                    onChange={(event) => onChainImportLandingChange('port', event.target.value)}
                     placeholder="端口"
                   />
                 </FormItem>
                 <FormItem label="账号（可选）">
                   <Input
-                    value={chainImportForm.first.username}
-                    onChange={(event) => onChainImportHopChange('first', 'username', event.target.value)}
+                    value={chainImportForm.landing.username}
+                    onChange={(event) => onChainImportLandingChange('username', event.target.value)}
                   />
                 </FormItem>
                 <FormItem label="密码（可选）">
                   <Input
                     type="password"
-                    value={chainImportForm.first.password}
-                    onChange={(event) => onChainImportHopChange('first', 'password', event.target.value)}
-                  />
-                </FormItem>
-              </div>
-            </div>
-            <div className="rounded-md border border-[var(--color-border)] p-3 space-y-3">
-              <h4 className="text-sm font-medium text-[var(--color-text-primary)]">第二层代理</h4>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <FormItem label="协议">
-                  <Select
-                    value={chainImportForm.second.protocol}
-                    onChange={(event) => onChainImportHopChange('second', 'protocol', event.target.value)}
-                    options={[
-                      { value: 'http', label: 'HTTP' },
-                      { value: 'socks5', label: 'SOCKS5' },
-                    ]}
-                  />
-                </FormItem>
-                <FormItem label="代理地址" required>
-                  <Input
-                    value={chainImportForm.second.server}
-                    onChange={(event) => onChainImportHopChange('second', 'server', event.target.value)}
-                    placeholder="代理地址"
-                  />
-                </FormItem>
-                <FormItem label="代理端口" required>
-                  <Input
-                    type="number"
-                    min={1}
-                    max={65535}
-                    value={chainImportForm.second.port}
-                    onChange={(event) => onChainImportHopChange('second', 'port', event.target.value)}
-                    placeholder="端口"
-                  />
-                </FormItem>
-                <FormItem label="账号（可选）">
-                  <Input
-                    value={chainImportForm.second.username}
-                    onChange={(event) => onChainImportHopChange('second', 'username', event.target.value)}
-                  />
-                </FormItem>
-                <FormItem label="密码（可选）">
-                  <Input
-                    type="password"
-                    value={chainImportForm.second.password}
-                    onChange={(event) => onChainImportHopChange('second', 'password', event.target.value)}
+                    value={chainImportForm.landing.password}
+                    onChange={(event) => onChainImportLandingChange('password', event.target.value)}
                   />
                 </FormItem>
               </div>

--- a/frontend/src/modules/browser/pages/proxyPool/ProxyPoolModals.tsx
+++ b/frontend/src/modules/browser/pages/proxyPool/ProxyPoolModals.tsx
@@ -1,6 +1,6 @@
 import { Button, FormItem, Input, Modal, Select, Table, Textarea } from '../../../../shared/components'
 import type { TableColumn } from '../../../../shared/components/Table'
-import type { ProxyIPHealthResult } from '../../types'
+import type { BrowserProxy, ProxyIPHealthResult } from '../../types'
 
 import {
   type ChainImportForm,
@@ -100,6 +100,8 @@ interface ProxyPoolEditModalProps {
   editForm: ProxyEditFormValue
   chainEditMode: boolean
   chainEditForm: ChainImportForm
+  chainKernelOptions: Array<{ value: string; label: string }>
+  frontProxyOptions: BrowserProxy[]
   directEditMode: boolean
   directEditForm: DirectImportForm
   onClose: () => void
@@ -107,7 +109,7 @@ interface ProxyPoolEditModalProps {
   onChange: (patch: Partial<ProxyEditFormValue>) => void
   onChainEditFormChange: (patch: Partial<ChainImportForm>) => void
   onDirectEditFormChange: (patch: Partial<DirectImportForm>) => void
-  onChainEditHopChange: (hop: 'first' | 'second', field: keyof ChainImportForm['first'], value: string) => void
+  onChainEditLandingChange: (field: keyof ChainImportForm['landing'], value: string) => void
 }
 
 export function ProxyPoolEditModal({
@@ -117,6 +119,8 @@ export function ProxyPoolEditModal({
   editForm,
   chainEditMode,
   chainEditForm,
+  chainKernelOptions,
+  frontProxyOptions,
   directEditMode,
   directEditForm,
   onClose,
@@ -124,7 +128,7 @@ export function ProxyPoolEditModal({
   onChange,
   onChainEditFormChange,
   onDirectEditFormChange,
-  onChainEditHopChange,
+  onChainEditLandingChange,
 }: ProxyPoolEditModalProps) {
   return (
     <Modal
@@ -178,7 +182,7 @@ export function ProxyPoolEditModal({
           <Select
             value={editForm.preferredKernel || 'auto'}
             onChange={(event) => onChange({ preferredKernel: event.target.value })}
-            options={[
+            options={chainEditMode ? chainKernelOptions : [
               { value: 'auto', label: '自动' },
               { value: 'xray', label: 'Xray' },
               { value: 'sing-box', label: 'sing-box' },
@@ -198,23 +202,34 @@ export function ProxyPoolEditModal({
                 placeholder="留空自动分配"
               />
             </FormItem>
+            <FormItem label="前置代理节点" required>
+              <Select
+                value={chainEditForm.frontProxyId}
+                onChange={(event) => onChainEditFormChange({ frontProxyId: event.target.value })}
+                options={[
+                  { value: '', label: '请选择前置节点' },
+                  ...frontProxyOptions.map(proxy => ({ value: proxy.proxyId, label: proxy.proxyName || proxy.proxyId })),
+                ]}
+              />
+            </FormItem>
             <div className="rounded-md border border-[var(--color-border)] p-3 space-y-3">
-              <h4 className="text-sm font-medium text-[var(--color-text-primary)]">第一层代理</h4>
+              <h4 className="text-sm font-medium text-[var(--color-text-primary)]">落地代理</h4>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <FormItem label="协议">
                   <Select
-                    value={chainEditForm.first.protocol}
-                    onChange={(event) => onChainEditHopChange('first', 'protocol', event.target.value)}
+                    value={chainEditForm.landing.protocol}
+                    onChange={(event) => onChainEditLandingChange('protocol', event.target.value)}
                     options={[
                       { value: 'http', label: 'HTTP' },
+                      { value: 'https', label: 'HTTPS' },
                       { value: 'socks5', label: 'SOCKS5' },
                     ]}
                   />
                 </FormItem>
                 <FormItem label="代理地址" required>
                   <Input
-                    value={chainEditForm.first.server}
-                    onChange={(event) => onChainEditHopChange('first', 'server', event.target.value)}
+                    value={chainEditForm.landing.server}
+                    onChange={(event) => onChainEditLandingChange('server', event.target.value)}
                   />
                 </FormItem>
                 <FormItem label="代理端口" required>
@@ -222,64 +237,21 @@ export function ProxyPoolEditModal({
                     type="number"
                     min={1}
                     max={65535}
-                    value={chainEditForm.first.port}
-                    onChange={(event) => onChainEditHopChange('first', 'port', event.target.value)}
+                    value={chainEditForm.landing.port}
+                    onChange={(event) => onChainEditLandingChange('port', event.target.value)}
                   />
                 </FormItem>
                 <FormItem label="账号（可选）">
                   <Input
-                    value={chainEditForm.first.username}
-                    onChange={(event) => onChainEditHopChange('first', 'username', event.target.value)}
+                    value={chainEditForm.landing.username}
+                    onChange={(event) => onChainEditLandingChange('username', event.target.value)}
                   />
                 </FormItem>
                 <FormItem label="密码（可选）">
                   <Input
                     type="password"
-                    value={chainEditForm.first.password}
-                    onChange={(event) => onChainEditHopChange('first', 'password', event.target.value)}
-                  />
-                </FormItem>
-              </div>
-            </div>
-            <div className="rounded-md border border-[var(--color-border)] p-3 space-y-3">
-              <h4 className="text-sm font-medium text-[var(--color-text-primary)]">第二层代理</h4>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <FormItem label="协议">
-                  <Select
-                    value={chainEditForm.second.protocol}
-                    onChange={(event) => onChainEditHopChange('second', 'protocol', event.target.value)}
-                    options={[
-                      { value: 'http', label: 'HTTP' },
-                      { value: 'socks5', label: 'SOCKS5' },
-                    ]}
-                  />
-                </FormItem>
-                <FormItem label="代理地址" required>
-                  <Input
-                    value={chainEditForm.second.server}
-                    onChange={(event) => onChainEditHopChange('second', 'server', event.target.value)}
-                  />
-                </FormItem>
-                <FormItem label="代理端口" required>
-                  <Input
-                    type="number"
-                    min={1}
-                    max={65535}
-                    value={chainEditForm.second.port}
-                    onChange={(event) => onChainEditHopChange('second', 'port', event.target.value)}
-                  />
-                </FormItem>
-                <FormItem label="账号（可选）">
-                  <Input
-                    value={chainEditForm.second.username}
-                    onChange={(event) => onChainEditHopChange('second', 'username', event.target.value)}
-                  />
-                </FormItem>
-                <FormItem label="密码（可选）">
-                  <Input
-                    type="password"
-                    value={chainEditForm.second.password}
-                    onChange={(event) => onChainEditHopChange('second', 'password', event.target.value)}
+                    value={chainEditForm.landing.password}
+                    onChange={(event) => onChainEditLandingChange('password', event.target.value)}
                   />
                 </FormItem>
               </div>
@@ -336,7 +308,7 @@ export function ProxyPoolEditModal({
               value={editForm.proxyConfig}
               onChange={(event) => onChange({ proxyConfig: event.target.value })}
               rows={10}
-              placeholder="支持 Clash YAML、chain+socks5:// 或其它高级配置"
+              placeholder="支持 Clash YAML、chain+proxy://、chain+socks5:// 或其它高级配置"
             />
           </FormItem>
         )}

--- a/frontend/src/modules/browser/pages/proxyPool/helpers.chain.ts
+++ b/frontend/src/modules/browser/pages/proxyPool/helpers.chain.ts
@@ -1,5 +1,15 @@
-import type { ChainHopForm, ChainImportForm, ChainSocks5Config, ChainSocks5HopConfig, ImportCandidate } from './helpers.types'
-import { CHAIN_SOCKS5_PREFIX } from './helpers.types'
+import type { ChainHopForm, ChainImportForm, ChainProxyConfig, ChainSocks5Config, ChainSocks5HopConfig, ImportCandidate } from './helpers.types'
+import { CHAIN_PROXY_PREFIX, CHAIN_SOCKS5_PREFIX } from './helpers.types'
+
+export function parseChainProxyConfig(proxyConfig: string): ChainProxyConfig | null {
+  const raw = proxyConfig.trim()
+  if (!raw.toLowerCase().startsWith(CHAIN_PROXY_PREFIX)) return null
+  try {
+    const cfg = JSON.parse(decodeURIComponent(raw.slice(CHAIN_PROXY_PREFIX.length))) as ChainProxyConfig
+    if (!cfg.frontProxyId || !cfg.landing?.server || !cfg.landing?.port) return null
+    return cfg
+  } catch { return null }
+}
 
 export function parseChainSocks5Config(proxyConfig: string): ChainSocks5Config | null {
   const cfg = proxyConfig.trim()
@@ -61,35 +71,28 @@ export function parseChainSocks5Config(proxyConfig: string): ChainSocks5Config |
 }
 
 export function toChainImportForm(proxyName: string, proxyConfig: string): ChainImportForm | null {
-  const cfg = parseChainSocks5Config(proxyConfig)
-  if (!cfg) {
-    return null
-  }
-
-  return {
-    proxyName,
-    localPort: cfg.localPort ? String(cfg.localPort) : '',
-    first: {
-      protocol: cfg.first.protocol,
-      server: cfg.first.server,
-      port: String(cfg.first.port),
-      username: cfg.first.username || '',
-      password: cfg.first.password || '',
-    },
-    second: {
-      protocol: cfg.second.protocol,
-      server: cfg.second.server,
-      port: String(cfg.second.port),
-      username: cfg.second.username || '',
-      password: cfg.second.password || '',
-    },
-  }
+  const cfg = parseChainProxyConfig(proxyConfig)
+  if (!cfg) return null
+  try {
+    return {
+      proxyName,
+      localPort: cfg.localPort ? String(cfg.localPort) : '',
+      frontProxyId: cfg.frontProxyId,
+      landing: {
+        protocol: cfg.landing.protocol,
+        server: cfg.landing.server,
+        port: String(cfg.landing.port),
+        username: cfg.landing.username || '',
+        password: cfg.landing.password || '',
+      },
+    }
+  } catch { return null }
 }
 
 
 export function buildChainImportCandidate(form: ChainImportForm): ImportCandidate {
   const parseHop = (label: string, hop: ChainHopForm): ChainSocks5HopConfig => {
-    const protocol = hop.protocol === 'socks5' ? 'socks5' : 'http'
+    const protocol = hop.protocol
     const server = hop.server.trim()
     if (!server) {
       throw new Error(`请输入${label}代理地址`)
@@ -135,15 +138,18 @@ export function buildChainImportCandidate(form: ChainImportForm): ImportCandidat
     throw new Error('本地监听端口必须在 1-65535 之间')
   }
 
-  const payload: ChainSocks5Config = {
-    first: parseHop('第一层', form.first),
-    second: parseHop('第二层', form.second),
+  const frontProxyId = form.frontProxyId.trim()
+  if (!frontProxyId) throw new Error('请选择前置代理节点')
+  const payload: ChainProxyConfig = {
+    version: 2,
+    frontProxyId,
+    landing: parseHop('落地', form.landing),
     localPort: localPort > 0 ? localPort : undefined,
   }
 
   return {
-    proxyName: form.proxyName.trim() || `链式代理-${payload.first.server}-${payload.second.server}`,
-    proxyConfig: `${CHAIN_SOCKS5_PREFIX}${encodeURIComponent(JSON.stringify(payload))}`,
+    proxyName: form.proxyName.trim() || `链式代理-${payload.landing.server}`,
+    proxyConfig: `${CHAIN_PROXY_PREFIX}${encodeURIComponent(JSON.stringify(payload))}`,
   }
 }
 
@@ -165,8 +171,8 @@ function parseChainQuickImportHop(raw: unknown, label: string): ChainSocks5HopCo
 
   const hop = raw as Record<string, unknown>
   const protocol = String(hop.protocol || 'socks5').trim().toLowerCase()
-  if (protocol !== 'socks5' && protocol !== 'http') {
-    throw new Error(`${label}仅支持 http / socks5`)
+  if (protocol !== 'socks5' && protocol !== 'http' && protocol !== 'https') {
+    throw new Error(`${label}仅支持 http / https / socks5`)
   }
 
   const server = String(hop.server || '').trim()
@@ -186,7 +192,7 @@ function parseChainQuickImportHop(raw: unknown, label: string): ChainSocks5HopCo
   }
 
   return {
-    protocol: protocol === 'http' ? 'http' : 'socks5',
+    protocol: protocol as ChainSocks5HopConfig['protocol'],
     server,
     port: portValue,
     username: username || undefined,
@@ -211,8 +217,9 @@ export function parseChainImportJSON(raw: string): { form: ChainImportForm; grou
     throw new Error('JSON 根节点必须是对象')
   }
 
-  const first = parseChainQuickImportHop(payload.first, '第一层')
-  const second = parseChainQuickImportHop(payload.second, '第二层')
+  const frontProxyId = String(payload.frontProxyId || '').trim()
+  if (!frontProxyId) throw new Error('缺少 frontProxyId')
+  const landing = parseChainQuickImportHop(payload.landing, '落地')
   const localPort = parseOptionalChainPort(payload.localPort, 'localPort')
   const proxyName = String(payload.name ?? payload.proxyName ?? '').trim()
   const groupName = String(payload.group ?? payload.groupName ?? '').trim()
@@ -221,19 +228,13 @@ export function parseChainImportJSON(raw: string): { form: ChainImportForm; grou
     form: {
       proxyName,
       localPort: localPort ? String(localPort) : '',
-      first: {
-        protocol: first.protocol,
-        server: first.server,
-        port: String(first.port),
-        username: first.username || '',
-        password: first.password || '',
-      },
-      second: {
-        protocol: second.protocol,
-        server: second.server,
-        port: String(second.port),
-        username: second.username || '',
-        password: second.password || '',
+      frontProxyId,
+      landing: {
+        protocol: landing.protocol,
+        server: landing.server,
+        port: String(landing.port),
+        username: landing.username || '',
+        password: landing.password || '',
       },
     },
     groupName,

--- a/frontend/src/modules/browser/pages/proxyPool/helpers.clash.ts
+++ b/frontend/src/modules/browser/pages/proxyPool/helpers.clash.ts
@@ -2,7 +2,7 @@ import yaml from 'js-yaml'
 import type { BrowserProxy } from '../../types'
 import type { ClashProxy, ImportCandidate, ProxyDisplayInfo } from './helpers.types'
 import { BUILTIN_PROXIES } from './helpers.types'
-import { parseChainSocks5Config } from './helpers.chain'
+import { parseChainProxyConfig, parseChainSocks5Config } from './helpers.chain'
 
 export function ensureBuiltinProxies(proxies: BrowserProxy[]): BrowserProxy[] {
   const result = [...proxies]
@@ -23,6 +23,15 @@ export function parseProxyInfo(proxyConfig: string): { type: string; server: str
     const firstHop = `${chain.first.server}:${chain.first.port}`
     const secondHop = `${chain.second.server}:${chain.second.port}`
     return { type: '链式', server: `${firstHop} → ${secondHop}`, port: chain.second.port }
+  }
+
+  const genericChain = parseChainProxyConfig(cfg)
+  if (genericChain) {
+    return {
+      type: '链式',
+      server: `${genericChain.frontProxyId} → ${genericChain.landing.server}:${genericChain.landing.port}`,
+      port: genericChain.localPort || 0,
+    }
   }
 
   const urlMatch = cfg.match(/^([a-zA-Z0-9+\-]+):\/\//)

--- a/frontend/src/modules/browser/pages/proxyPool/helpers.types.ts
+++ b/frontend/src/modules/browser/pages/proxyPool/helpers.types.ts
@@ -26,7 +26,7 @@ export interface DirectImportForm {
 }
 
 export interface ChainHopForm {
-  protocol: 'http' | 'socks5'
+  protocol: 'http' | 'https' | 'socks5'
   server: string
   port: string
   username: string
@@ -36,12 +36,12 @@ export interface ChainHopForm {
 export interface ChainImportForm {
   proxyName: string
   localPort: string
-  first: ChainHopForm
-  second: ChainHopForm
+  frontProxyId: string
+  landing: ChainHopForm
 }
 
 export interface ChainSocks5HopConfig {
-  protocol: 'http' | 'socks5'
+  protocol: 'http' | 'https' | 'socks5'
   server: string
   port: number
   username?: string
@@ -55,20 +55,22 @@ export interface ChainSocks5Config {
 }
 
 export const CHAIN_SOCKS5_PREFIX = 'chain+socks5://'
+export const CHAIN_PROXY_PREFIX = 'chain+proxy://'
+
+export interface ChainProxyConfig {
+  version: 2
+  frontProxyId: string
+  landing: ChainSocks5HopConfig
+  localPort?: number
+}
 
 export const CHAIN_QUICK_IMPORT_TEMPLATE = `{
   "name": "",
   "group": "",
   "localPort": "",
-  "first": {
-    "protocol": "http",
-    "server": "",
-    "port": "",
-    "username": "",
-    "password": ""
-  },
-  "second": {
-    "protocol": "http",
+  "frontProxyId": "从代理池选择或填写节点 ID",
+  "landing": {
+    "protocol": "socks5",
     "server": "",
     "port": "",
     "username": "",
@@ -104,15 +106,9 @@ export const INITIAL_DIRECT_IMPORT_FORM: DirectImportForm = {
 export const INITIAL_CHAIN_IMPORT_FORM: ChainImportForm = {
   proxyName: '',
   localPort: '',
-  first: {
-    protocol: 'http',
-    server: '',
-    port: '',
-    username: '',
-    password: '',
-  },
-  second: {
-    protocol: 'http',
+  frontProxyId: '',
+  landing: {
+    protocol: 'socks5',
     server: '',
     port: '',
     username: '',
@@ -123,8 +119,7 @@ export const INITIAL_CHAIN_IMPORT_FORM: ChainImportForm = {
 export function createInitialChainImportForm(): ChainImportForm {
   return {
     ...INITIAL_CHAIN_IMPORT_FORM,
-    first: { ...INITIAL_CHAIN_IMPORT_FORM.first },
-    second: { ...INITIAL_CHAIN_IMPORT_FORM.second },
+    landing: { ...INITIAL_CHAIN_IMPORT_FORM.landing },
   }
 }
 

--- a/frontend/src/modules/browser/pages/proxyPool/useProxyImportFlow.ts
+++ b/frontend/src/modules/browser/pages/proxyPool/useProxyImportFlow.ts
@@ -35,8 +35,7 @@ interface UseProxyImportFlowOptions {
 function createInitialChainImportForm(): ChainImportForm {
   return {
     ...INITIAL_CHAIN_IMPORT_FORM,
-    first: { ...INITIAL_CHAIN_IMPORT_FORM.first },
-    second: { ...INITIAL_CHAIN_IMPORT_FORM.second },
+    landing: { ...INITIAL_CHAIN_IMPORT_FORM.landing },
   }
 }
 
@@ -73,11 +72,11 @@ export function useProxyImportFlow({
     setPreviewList(prev => prev.filter(item => item.proxyId !== proxyId))
   }
 
-  const updateChainImportHop = (hop: 'first' | 'second', field: keyof ChainImportForm['first'], value: string) => {
+  const updateChainImportLanding = (field: keyof ChainImportForm['landing'], value: string) => {
     setChainImportForm(prev => ({
       ...prev,
-      [hop]: {
-        ...prev[hop],
+      landing: {
+        ...prev.landing,
         [field]: value,
       },
     }))
@@ -284,10 +283,9 @@ export function useProxyImportFlow({
     ? !!importText.trim()
     : importMode === 'direct'
       ? !!directImportText.trim() || (!!directImportForm.server.trim() && !!directImportForm.port.trim())
-      : !!chainImportForm.first.server.trim()
-        && !!chainImportForm.first.port.trim()
-        && !!chainImportForm.second.server.trim()
-        && !!chainImportForm.second.port.trim()
+      : !!chainImportForm.frontProxyId.trim()
+        && !!chainImportForm.landing.server.trim()
+        && !!chainImportForm.landing.port.trim()
 
   return {
     importModalOpen, setImportModalOpen, importMode, importUrl, importFetchProxyId, importResolvedUrl, importText,
@@ -295,7 +293,7 @@ export function useProxyImportFlow({
     chainImportForm, directImportForm, previewModalOpen, setPreviewModalOpen, previewList, removedPreviewProxyNames,
     importing, fetchingImportUrl, canParseImport, setImportText, setImportDnsServers,
     setImportNamePrefix, setImportGroupName, setImportFetchProxyId, setChainImportText, setDirectImportText,
-    setChainImportForm, setDirectImportForm, handleRemovePreviewProxy, updateChainImportHop,
+    setChainImportForm, setDirectImportForm, handleRemovePreviewProxy, updateChainImportLanding,
     handleImportModeChange, handleFillChainTemplate, handleFillDirectTemplate, handleCopyChainTemplate,
     handleCopyDirectTemplate, handleApplyChainJSON, handleApplyDirectText, handleImportUrlChange,
     handleFetchImportURL, handleParseImport, handleConfirmImport,


### PR DESCRIPTION
## Summary

Closes #60.

Extend chain proxy support so an existing imported proxy-pool node can be used as the front hop, while an HTTP/HTTPS or SOCKS5 proxy remains the final landing hop.

Example:

VLESS front hop → authenticated SOCKS5 landing → target website

This is incremental to the existing `chain+socks5` implementation and keeps the legacy two-SOCKS-hop format compatible.

## Changes

- Add a `chain+proxy://` configuration format referencing an existing proxy-pool node by ID.
- Allow imported VLESS, VMess, Trojan, Shadowsocks, Hysteria/Hysteria2, TUIC, AnyTLS, Mieru and WireGuard nodes to act as front hops according to kernel support.
- Route the landing proxy through the selected front node:
  - Xray: `proxySettings`
  - sing-box: `detour`
  - Mihomo: `dialer-proxy`
- Automatically resolve the compatible kernel from the front-hop protocol.
- Reject missing, self-referencing and nested chain nodes.
- Support HTTP, HTTPS and SOCKS5 landing proxies with authentication.
- Update proxy-pool import/edit forms to select an imported front node and show compatible kernels.
- Extend diagnostics and speed testing to use the complete chain.

## Verification

- `go test ./...`
- TypeScript type checking
- Real VLESS → authenticated SOCKS5 chain test
- Verified the browser-facing local SOCKS endpoint and final landing route